### PR TITLE
[Team-04, BE] 이슈 필터링 API & 리팩토링 및 버그 수정

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -28,7 +28,7 @@ jobs:
         run: ls -l backend/build/libs
 
       - name: Upload JAR artifact (optional)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: backend-jar
           path: backend/build/libs/*.jar

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch:
+   
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -23,13 +23,9 @@ jobs:
 
       - name: Build Backend (Skip tests)
         working-directory: backend
-        run: ./gradlew clean build -x test
-
-      - name: Set up SSH key
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          ./gradlew clean build -x test
+          ls -l build/libs/
 
       - name: Upload jar to EC2
         uses: appleboy/scp-action@v0.1.7
@@ -37,8 +33,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: backend/build/libs/issue-tracker-0.0.1-SNAPSHOT.jar
-          target: /home/ubuntu/issue-tracker/backend/build/libs/
+          source: backend/build/libs/
+          target: /home/ubuntu/issue-tracker/backend/build/libs
 
       - name: Deploy and run backend on EC2
         uses: appleboy/ssh-action@master

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,4 +1,3 @@
-# .github/workflows/deploy-backend.yml
 name: Deploy Backend to EC2
 
 on:
@@ -7,41 +6,43 @@ on:
     paths:
       - 'backend/**'
   workflow_dispatch:
-  
+
 jobs:
-  deploy-backend:
+  deploy:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: '21'
-          distribution: 'temurin'
+      - name: Set up SSH Key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.EC2_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
 
-      - name: Build Backend
-        working-directory: backend
-        run: ./gradlew build -x test
+      - name: Deploy and Run on EC2
+        run: |
+          ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} << 'EOF'
+          
+          # 로그 디렉토리 준비
+          sudo mkdir -p /var/log/issue-tracker
+          sudo chown $(whoami):$(whoami) /var/log/issue-tracker
 
-      - name: Upload to EC2
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY }}
-          source: "backend/build/libs/*.jar"
-          target: "/home/ubuntu/issue-tracker/backend/build/libs"
+          # 프로젝트 디렉토리로 이동
+          cd ~/issue-tracker
 
-      - name: Run on EC2
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY }}
-          script: |
-            cd /home/ubuntu/issue-tracker/backend/build/libs
-            pkill -f 'java -jar' || true
-            nohup java -jar *.jar > /home/ubuntu/issue-tracker/backend/log.txt 2>&1 &
-            
+          # 최신 코드 pull
+          git checkout main
+          git pull origin main
+
+          # 빌드
+          chmod +x ./gradlew
+          ./gradlew -p backend build -x test
+
+          # 기존 실행 중인 서버 종료
+          pkill -f 'java -jar' || true
+
+          # 실행
+          nohup java -jar backend/build/libs/backend-0.0.1-SNAPSHOT.jar > /var/log/issue-tracker/app.log 2>&1 &
+          EOF

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -12,37 +12,55 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Code
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up SSH Key
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build Backend (Skip tests)
+        working-directory: backend
+        run: ./gradlew clean build -x test
+
+      - name: Set up SSH key
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.EC2_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
 
-      - name: Deploy and Run on EC2
-        run: |
-          ssh -o StrictHostKeyChecking=no ubuntu@${{ secrets.EC2_HOST }} << 'EOF'
-          
-          # 로그 디렉토리 준비
-          sudo mkdir -p /var/log/issue-tracker
-          sudo chown $(whoami):$(whoami) /var/log/issue-tracker
+      - name: Upload jar to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          source: backend/build/libs/issue-tracker-0.0.1-SNAPSHOT.jar
+          target: /home/ubuntu/issue-tracker/backend/build/libs/
 
-          # 프로젝트 디렉토리로 이동
-          cd ~/issue-tracker
+      - name: Deploy and run backend on EC2
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            PROJECT_NAME="issue-tracker"
+            BACKEND_DIR="/home/ubuntu/$PROJECT_NAME"
+            JAR_NAME="issue-tracker-0.0.1-SNAPSHOT.jar"
+            BUILD_DIR="$BACKEND_DIR/backend/build/libs"
+            LOG_FILE="/home/ubuntu/nohup.out"
 
-          # 최신 코드 pull
-          git checkout main
-          git pull origin main
+            echo "🛑 기존 백엔드 종료..."
+            PID=$(pgrep -f $JAR_NAME) || true
+            if [ -n "$PID" ]; then
+              kill -9 $PID
+              echo "✅ 종료 완료 (PID=$PID)"
+            else
+              echo "⚠️ 실행 중인 백엔드 없음"
+            fi
 
-          # 빌드
-          chmod +x ./gradlew
-          ./gradlew -p backend build -x test
-
-          # 기존 실행 중인 서버 종료
-          pkill -f 'java -jar' || true
-
-          # 실행
-          nohup java -jar backend/build/libs/backend-0.0.1-SNAPSHOT.jar > /var/log/issue-tracker/app.log 2>&1 &
-          EOF
+            echo "🚀 백엔드 실행 중..."
+            nohup java -jar $BUILD_DIR/$JAR_NAME > $LOG_FILE 2>&1 &

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -30,8 +30,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
-          source: "backend/"
-          target: "/home/ubuntu/issue-tracker/backend"
+          source: "backend/build/libs/*.jar"
+          target: "/home/ubuntu/issue-tracker/backend/build/libs"
 
       - name: Run on EC2
         uses: appleboy/ssh-action@master
@@ -40,7 +40,7 @@ jobs:
           username: ubuntu
           key: ${{ secrets.EC2_KEY }}
           script: |
-            cd /home/ubuntu/issue-tracker/backend
-            ./gradlew build -x test
+            cd /home/ubuntu/issue-tracker/backend/build/libs
             pkill -f 'java -jar' || true
-            nohup java -jar build/libs/*.jar > log.txt 2>&1 &
+            nohup java -jar *.jar > /home/ubuntu/issue-tracker/backend/log.txt 2>&1 &
+            

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -6,7 +6,8 @@ on:
     branches: [ main ]
     paths:
       - 'backend/**'
-
+  workflow_dispatch:
+  
 jobs:
   deploy-backend:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,62 +1,82 @@
-name: Deploy Backend to EC2
+name: Build and Deploy Backend
 
 on:
   push:
-    branches: [ main ]
-    paths:
-      - 'backend/**'
-  workflow_dispatch:
+    branches:
+      - main
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v3
 
       - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          distribution: temurin
+          java-version: 21
 
-      - name: Build Backend (Skip tests)
-        working-directory: backend
-        run: |
-          ./gradlew clean build -x test
-          ls -l build/libs/
+      - name: Build backend with Gradle
+        working-directory: ./backend
+        run: ./gradlew clean build
 
-      - name: Upload jar to EC2
-        uses: appleboy/scp-action@v0.1.7
+      - name: List build/libs to check JAR
+        run: ls -l backend/build/libs
+
+      - name: Upload JAR artifact (optional)
+        uses: actions/upload-artifact@v3
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY }}
-          source: backend/build/libs/
-          target: /home/ubuntu/issue-tracker/backend/build/libs
+          name: backend-jar
+          path: backend/build/libs/*.jar
 
-      - name: Deploy and run backend on EC2
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download backend JAR artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: backend-jar
+          path: ./deploy-artifacts
+
+      - name: Deploy to EC2 via SSH
         uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
-          key: ${{ secrets.EC2_KEY }}
+          key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             PROJECT_NAME="issue-tracker"
-            BACKEND_DIR="/home/ubuntu/$PROJECT_NAME"
-            JAR_NAME="issue-tracker-0.0.1-SNAPSHOT.jar"
-            BUILD_DIR="$BACKEND_DIR/backend/build/libs"
-            LOG_FILE="/home/ubuntu/nohup.out"
+            DEPLOY_DIR="/home/ubuntu/$PROJECT_NAME"
+            LOG_DIR="$DEPLOY_DIR/logs"
+            LOG_FILE="$LOG_DIR/app.log"
+            JAR_NAME=$(ls ./deploy-artifacts/*.jar | xargs -n1 basename)
 
-            echo "🛑 기존 백엔드 종료..."
-            PID=$(pgrep -f $JAR_NAME) || true
+            mkdir -p "$DEPLOY_DIR"
+            mkdir -p "$LOG_DIR"
+
+            echo "🛑 기존 프로세스 종료 중..."
+            PID=$(pgrep -f "$JAR_NAME" || true)
             if [ -n "$PID" ]; then
               kill -9 $PID
               echo "✅ 종료 완료 (PID=$PID)"
             else
-              echo "⚠️ 실행 중인 백엔드 없음"
+              echo "⚠️ 실행 중인 프로세스 없음"
             fi
 
-            echo "🚀 백엔드 실행 중..."
-            nohup java -jar $BUILD_DIR/$JAR_NAME > $LOG_FILE 2>&1 &
+            echo "🚀 새 백엔드 실행..."
+            nohup java -jar "$DEPLOY_DIR/$JAR_NAME" > "$LOG_FILE" 2>&1 &
+
+            echo "✅ 배포 완료 (PID=$!)"
+
+      - name: Copy JAR to EC2
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ubuntu
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: ./deploy-artifacts/*.jar
+          target: /home/ubuntu/issue-tracker/

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -41,6 +41,6 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd /home/ubuntu/issue-tracker/backend
-            ./gradlew bootJar
+            ./gradlew build -x test
             pkill -f 'java -jar' || true
             nohup java -jar build/libs/*.jar > log.txt 2>&1 &

--- a/backend/.editorconfig
+++ b/backend/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,1 +1,2 @@
 backend/.idea/
+.idea/

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.3')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
@@ -7,13 +7,9 @@ import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -47,5 +43,11 @@ public class CommentController {
 
         CommentResponseDto.UpdateCommentDto response = commentService.updateComment(commentId, request, uploadUrl);
         return ApiResponse.success(response);
+    }
+
+    @DeleteMapping("/{issue-id}/{cpmment-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteComment(@PathVariable("issue-id") Long issueId, @PathVariable("comment-id") Long commentId) {
+        commentService.deleteComment(issueId, commentId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
@@ -45,7 +45,7 @@ public class CommentController {
         return ApiResponse.success(response);
     }
 
-    @DeleteMapping("/{issue-id}/{cpmment-id}")
+    @DeleteMapping("/{issue-id}/{comment-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@PathVariable("issue-id") Long issueId, @PathVariable("comment-id") Long commentId) {
         commentService.deleteComment(issueId, commentId);

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
@@ -60,7 +60,7 @@ public class CommentService {
                 .orElseThrow(() -> new CommentNotFoundException(commentId));
 
         if (!comment.getIssueId().equals(issueId)) {
-            throw new InvalidCommentAccessException(); // 선택사항
+            throw new InvalidCommentAccessException();
         }
 
         commentRepository.deleteById(commentId);

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
@@ -3,6 +3,7 @@ package codesquad.team4.issuetracker.comment;
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Comment;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidCommentAccessException;
 import codesquad.team4.issuetracker.exception.notfound.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,5 +53,16 @@ public class CommentService {
                 .id(commentId)
                 .message(UPDATE_COMMENT)
                 .build();
+    }
+
+    public void deleteComment(Long issueId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getIssueId().equals(issueId)) {
+            throw new InvalidCommentAccessException(); // 선택사항
+        }
+
+        commentRepository.deleteById(commentId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentRequestDto.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.comment.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class CommentRequestDto {
     @Getter
     @Builder
     public static class UpdateCommentDto {
-        @NotNull
+        @NotEmpty
         private String content;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/SwaggerConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package codesquad.team4.issuetracker.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Issue Tracker API", version = "v1", description = "이슈 및 댓글 관리 API 문서입니다.")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        SecurityScheme apiKey = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization")
+            .scheme("bearer")
+            .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList("Bearer Token");
+
+        return new OpenAPI()
+            .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+            .addSecurityItem(securityRequirement);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -10,4 +10,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_LABEL = "존재하지 않는 label ID: ";
     public static final String NOT_FOUND_ASSIGNEE = "존재하지 않는 assignee ID: ";
     public static final String NOT_FOUND_COMMENT = "댓글을 찾을 수 없습니다. commentId = ";
+    public static final String INVALID_COMMENT_ACCESS = "댓글이 이슈에 속하지 않습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -11,4 +11,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_ASSIGNEE = "존재하지 않는 assignee ID: ";
     public static final String NOT_FOUND_COMMENT = "댓글을 찾을 수 없습니다. commentId = ";
     public static final String INVALID_COMMENT_ACCESS = "댓글이 이슈에 속하지 않습니다.";
+    public static final String INVALID_FILTERING_CONDITION = "authorId, assigneeId, commentAuthorId 중 하나만 사용할 수 있습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package codesquad.team4.issuetracker.exception;
 import codesquad.team4.issuetracker.exception.badrequest.InvalidRequestException;
 import codesquad.team4.issuetracker.exception.notfound.DataNotFoundException;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidCommentAccessException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidCommentAccessException.java
@@ -1,0 +1,9 @@
+package codesquad.team4.issuetracker.exception.badrequest;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.INVALID_COMMENT_ACCESS;
+
+public class InvalidCommentAccessException extends InvalidRequestException {
+    public InvalidCommentAccessException() {
+        super(INVALID_COMMENT_ACCESS);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidFilteringConditionException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidFilteringConditionException.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.exception.badrequest;
+
+public class InvalidFilteringConditionException extends InvalidRequestException {
+    public InvalidFilteringConditionException(String message) {
+        super(message);
+    }
+
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/LabelNotFoundException.java
@@ -9,4 +9,6 @@ public class LabelNotFoundException extends DataNotFoundException {
     public LabelNotFoundException(Set<Long> labelIds) {
         super(NOT_FOUND_LABEL + labelIds);
     }
+
+    public LabelNotFoundException(Long labelId) { super(NOT_FOUND_LABEL + labelId);}
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -60,8 +60,8 @@ public class IssueController {
     }
 
     @PatchMapping("/status")
-    public ApiResponse<IssueResponseDto.BulkUpdateIssueStatusDto> updateIssueStatus(
-            @RequestBody IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
+    public ResponseEntity<ApiResponse<IssueResponseDto.BulkUpdateIssueStatusDto>> updateIssueStatus(
+            @RequestBody @Valid IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
 
         IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -1,12 +1,18 @@
 package codesquad.team4.issuetracker.issue;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.INVALID_FILTERING_CONDITION;
+
 import codesquad.team4.issuetracker.aws.S3FileService;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidFilteringConditionException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -38,10 +44,22 @@ public class IssueController {
 
     @GetMapping("")
     public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@Valid IssueRequestDto.IssueFilterParamDto params, Pageable pageable) {
+        //authorId, assigneeId, commentAuthorId 중 두개 이상의 조건은 불가
+        validateFilterConditionCount(params);
 
         IssueResponseDto.IssueListDto issues = issueService.getIssues(params, pageable.getPageNumber(), pageable.getPageSize());
 
         return ApiResponse.success(issues);
+    }
+
+    private void validateFilterConditionCount(IssueFilterParamDto params) {
+        long filterCount = Stream.of(params.getAuthorId(), params.getAssigneeId(), params.getCommentAuthorId())
+            .filter(Objects::nonNull)
+            .count();
+
+        if (filterCount > 1) {
+            throw new InvalidFilteringConditionException(INVALID_FILTERING_CONDITION);
+        }
     }
 
     @GetMapping("/count")

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -11,16 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -65,7 +57,7 @@ public class IssueController {
 
         IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
 
-        return ApiResponse.success(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @GetMapping("/{issue-id}")
@@ -88,7 +80,7 @@ public class IssueController {
     }
 
     @PutMapping("/{issueId}/labels")
-    public ApiResponse<IssueResponseDto.ApiMessageDto> updateIssueLabels(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueLabelsUpdateDto request) {
+    public ApiResponse<ApiMessageDto> updateIssueLabels(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueLabelsUpdateDto request) {
 
         ApiMessageDto result = issueService.updateLabels(issueId, request.getLabels());
 
@@ -96,7 +88,7 @@ public class IssueController {
     }
 
     @PutMapping("/{issueId}/assignees")
-    public ApiResponse<IssueResponseDto.ApiMessageDto> updateIssueAssignees(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueAssigneeUpdateDto request) {
+    public ApiResponse<ApiMessageDto> updateIssueAssignees(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueAssigneeUpdateDto request) {
 
         ApiMessageDto result = issueService.updateAssignees(issueId, request.getAssignees());
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -10,9 +10,20 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -52,12 +63,12 @@ public class IssueController {
     }
 
     @PatchMapping("/status")
-    public ResponseEntity<ApiResponse<IssueResponseDto.BulkUpdateIssueStatusDto>> updateIssueStatus(
+    public ApiResponse<IssueResponseDto.BulkUpdateIssueStatusDto> updateIssueStatus(
             @RequestBody @Valid IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
 
         IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
 
-        return ResponseEntity.ok(ApiResponse.success(result));
+        return ApiResponse.success(result);
     }
 
     @GetMapping("/{issue-id}")
@@ -79,19 +90,25 @@ public class IssueController {
         return ApiResponse.success(result);
     }
 
-    @PutMapping("/{issueId}/labels")
-    public ApiResponse<ApiMessageDto> updateIssueLabels(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueLabelsUpdateDto request) {
+    @PutMapping("/{issue-id}/labels")
+    public ApiResponse<IssueResponseDto.ApiMessageDto> updateIssueLabels(@PathVariable("issue-id") Long issueId, @RequestBody IssueRequestDto.IssueLabelsUpdateDto request) {
 
         ApiMessageDto result = issueService.updateLabels(issueId, request.getLabels());
 
         return ApiResponse.success(result);
     }
 
-    @PutMapping("/{issueId}/assignees")
-    public ApiResponse<ApiMessageDto> updateIssueAssignees(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueAssigneeUpdateDto request) {
+    @PutMapping("/{issue-id}/assignees")
+    public ApiResponse<IssueResponseDto.ApiMessageDto> updateIssueAssignees(@PathVariable("issue-id") Long issueId, @RequestBody IssueRequestDto.IssueAssigneeUpdateDto request) {
 
         ApiMessageDto result = issueService.updateAssignees(issueId, request.getAssignees());
 
         return ApiResponse.success(result);
+    }
+
+    @DeleteMapping("/{issue-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteIssue(@PathVariable("issue-id") Long issueId) {
+        issueService.deleteIssue(issueId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,9 +37,9 @@ public class IssueController {
     private final S3FileService s3FileService;
 
     @GetMapping("")
-    public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(name = "is_open") boolean isOpen, Pageable pageable) {
+    public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@Valid IssueRequestDto.IssueFilterParamDto params, Pageable pageable) {
 
-        IssueResponseDto.IssueListDto issues = issueService.getIssues(isOpen, pageable.getPageNumber(), pageable.getPageSize());
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(params, pageable.getPageNumber(), pageable.getPageSize());
 
         return ApiResponse.success(issues);
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -1,5 +1,11 @@
     package codesquad.team4.issuetracker.issue;
 
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.jdbc.core.JdbcTemplate;
+    import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+    import org.springframework.stereotype.Repository;
+
+    import java.util.*;
     import java.util.ArrayList;
     import java.util.List;
     import java.util.Map;
@@ -51,12 +57,13 @@
             );
         }
 
-        public List<Long> findExistingIssueIds(List<Long> issueIds) {
+        public Set<Long> findExistingIssueIds(List<Long> issueIds) {
             String placeholders = issueIds.stream().map(id -> "?").collect(Collectors.joining(", "));
             String sql = "SELECT issue_id FROM issue WHERE issue_id IN (" + placeholders + ")";
-            return jdbcTemplate.query(sql,
-                    (rs, rowNum) -> rs.getLong("issue_id"),
-                    issueIds.toArray());
+            List<Long> results = jdbcTemplate.query(sql,
+                (rs, rowNum) -> rs.getLong("issue_id"),
+                issueIds.toArray());
+            return new HashSet<>(results);
         }
 
         public int updateIssueStatusByIds(boolean isOpen, List<Long> issueIds) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -1,14 +1,11 @@
     package codesquad.team4.issuetracker.issue;
 
-    import lombok.RequiredArgsConstructor;
-    import org.springframework.jdbc.core.JdbcTemplate;
-    import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-    import org.springframework.stereotype.Repository;
-
-    import java.util.*;
+    import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
     import java.util.ArrayList;
+    import java.util.HashSet;
     import java.util.List;
     import java.util.Map;
+    import java.util.Set;
     import java.util.stream.Collectors;
     import lombok.RequiredArgsConstructor;
     import org.springframework.jdbc.core.JdbcTemplate;
@@ -20,9 +17,9 @@
 
         private final JdbcTemplate jdbcTemplate;
 
-        public List<Map<String, Object>> findIssuesByOpenStatus(boolean isOpen){
+        public List<Map<String, Object>> findIssuesByOpenStatus(IssueRequestDto.IssueFilterParamDto dto){
 
-            String sql = """
+            StringBuilder sql = new StringBuilder("""
                 SELECT i.issue_id AS issue_id,
                        i.title,
                        u.user_id AS author_id,
@@ -44,9 +41,33 @@
                 LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id
                 LEFT JOIN `user` a ON ia.assignee_id = a.user_id
                 WHERE i.is_open = ?
-            """;
+            """);
 
-            return jdbcTemplate.queryForList(sql, isOpen);
+            List<Object> params = new ArrayList<>();
+            params.add(dto.getIsOpen());
+
+            if (dto.getAuthorId() != null) {
+                sql.append(" AND i.author_id = ?");
+                params.add(dto.getAuthorId());
+            }
+
+            if (dto.getAssigneeId() != null) {
+                sql.append(" AND a.user_id = ?");
+                params.add(dto.getAssigneeId());
+            }
+
+            if (dto.getCommentAuthorId() != null) {
+                sql.append("""
+                    AND EXISTS (
+                        SELECT 1 FROM comment c
+                        WHERE c.issue_id = i.issue_id
+                        AND c.author_id = ?
+                    )
+                """);
+                params.add(dto.getCommentAuthorId());
+            }
+
+            return jdbcTemplate.queryForList(sql.toString(), params.toArray());
         }
 
         public int countIssuesByOpenStatus(boolean isOpen) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -6,6 +6,10 @@ import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.exception.AssigneeNotFoundException;
+import codesquad.team4.issuetracker.exception.IssueNotFoundException;
+import codesquad.team4.issuetracker.exception.LabelNotFoundException;
+import codesquad.team4.issuetracker.exception.MilestoneNotFoundException;
 import codesquad.team4.issuetracker.exception.ExceptionMessage;
 import codesquad.team4.issuetracker.exception.badrequest.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException;
@@ -189,15 +193,18 @@ public class IssueService {
         List<Long> issueIds = request.getIssuesId();
         boolean isOpen = request.isOpen();
 
-        List<Long> existingIds = issueDao.findExistingIssueIds(issueIds);
+        Set<Long> existingIdsSet = issueDao.findExistingIssueIds(issueIds);
+        List<Long> existingIds = new ArrayList<>(existingIdsSet);
 
         List<Long> missingIds = issueIds.stream()
-                .filter(id -> !existingIds.contains(id))
-                .toList();
+            .filter(id -> !existingIdsSet.contains(id))
+            .toList();
 
-        if (!existingIds.isEmpty()) {
+
+        if (!existingIdsSet.isEmpty()) {
             issueDao.updateIssueStatusByIds(isOpen, existingIds);
         }
+
         String message = missingIds.isEmpty()
                 ? UPDATE_ISSUESTATUS
                 : String.format(ISSUE_PARTIALLY_UPDATED, missingIds);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -19,8 +19,8 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.searchIssueDetailDto;
 import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.label.LabelDao;
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.AssigneeDao;
@@ -65,7 +65,7 @@ public class IssueService {
 
         Map<Long, IssueResponseDto.IssueInfo> issueMap = new LinkedHashMap<>();
         Map<Long, Set<UserInfo>> assigneeMap = new HashMap<>();
-        Map<Long, Set<LabelDto.LabelInfo>> labelMap = new HashMap<>();
+        Map<Long, Set<LabelResponseDto.LabelInfo>> labelMap = new HashMap<>();
 
         for (Map<String, Object> row : rows) {
             Long issueId = (Long) row.get("issue_id");

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -12,6 +12,7 @@ import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
+import codesquad.team4.issuetracker.exception.*;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;
@@ -23,6 +24,7 @@ import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.label.LabelDao;
 import codesquad.team4.issuetracker.label.dto.LabelDto;
 import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelDto;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.AssigneeDao;
@@ -39,9 +41,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import codesquad.team4.issuetracker.user.dto.UserDto;
+import codesquad.team4.issuetracker.user.dto.UserDto.UserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -180,10 +188,6 @@ public class IssueService {
     public IssueResponseDto.BulkUpdateIssueStatusDto bulkUpdateIssueStatus(IssueRequestDto.BulkUpdateIssueStatusDto request) {
         List<Long> issueIds = request.getIssuesId();
         boolean isOpen = request.isOpen();
-
-        if (issueIds == null || issueIds.isEmpty()) {
-            throw new IssueStatusUpdateException(ExceptionMessage.NO_ISSUE_IDS);
-        }
 
         List<Long> existingIds = issueDao.findExistingIssueIds(issueIds);
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -1,22 +1,13 @@
 package codesquad.team4.issuetracker.issue;
 
-import static codesquad.team4.issuetracker.aws.S3FileService.EMPTY_STRING;
-
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
-import codesquad.team4.issuetracker.exception.AssigneeNotFoundException;
-import codesquad.team4.issuetracker.exception.IssueNotFoundException;
-import codesquad.team4.issuetracker.exception.LabelNotFoundException;
-import codesquad.team4.issuetracker.exception.MilestoneNotFoundException;
-import codesquad.team4.issuetracker.exception.ExceptionMessage;
-import codesquad.team4.issuetracker.exception.badrequest.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
-import codesquad.team4.issuetracker.exception.*;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;
@@ -28,23 +19,11 @@ import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.label.LabelDao;
 import codesquad.team4.issuetracker.label.dto.LabelDto;
 import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
-import codesquad.team4.issuetracker.label.dto.LabelDto;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.AssigneeDao;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import codesquad.team4.issuetracker.user.UserDao;
-import codesquad.team4.issuetracker.user.dto.UserDto;
-import codesquad.team4.issuetracker.user.dto.UserDto.UserInfo;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import codesquad.team4.issuetracker.user.dto.UserDto.UserInfo;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +33,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.*;
+
+import static codesquad.team4.issuetracker.aws.S3FileService.EMPTY_STRING;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -1,5 +1,7 @@
 package codesquad.team4.issuetracker.issue;
 
+import static codesquad.team4.issuetracker.aws.S3FileService.EMPTY_STRING;
+
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
@@ -26,15 +28,18 @@ import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import codesquad.team4.issuetracker.user.UserDao;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import codesquad.team4.issuetracker.user.dto.UserDto.UserInfo;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static codesquad.team4.issuetracker.aws.S3FileService.EMPTY_STRING;
 
 @Service
 @RequiredArgsConstructor
@@ -55,8 +60,8 @@ public class IssueService {
     private final IssueAssigneeRepository issueAssigneeRepository;
     private final MilestoneRepository milestoneRepository;
 
-    public IssueResponseDto.IssueListDto getIssues(boolean isOpen, int page, int size) {
-        List<Map<String, Object>> rows = issueDao.findIssuesByOpenStatus(isOpen);
+    public IssueResponseDto.IssueListDto getIssues(IssueRequestDto.IssueFilterParamDto params, int page, int size) {
+        List<Map<String, Object>> rows = issueDao.findIssuesByOpenStatus(params);
 
         Map<Long, IssueResponseDto.IssueInfo> issueMap = new LinkedHashMap<>();
         Map<Long, Set<UserInfo>> assigneeMap = new HashMap<>();
@@ -72,7 +77,7 @@ public class IssueService {
 
         List<IssueInfo> issues = pagenateList(page, size, issueMap);
 
-        int totalElements = issueDao.countIssuesByOpenStatus(isOpen);
+        int totalElements = issueDao.countIssuesByOpenStatus(params.getIsOpen());
         int totalPages = (int) Math.ceil((double) totalElements / size);
 
         return IssueResponseDto.IssueListDto.builder()

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -251,17 +251,21 @@ public class IssueService {
         //기존 이미지를 삭제하는 것인지 확인
         String newFileUrl = determineNewFileUrl(request, uploadUrl, oldIssue);
 
-        Issue updated = oldIssue.toBuilder()
+        Issue updated = createupdatedIssue(request, oldIssue, newFileUrl);
+
+        issueRepository.save(updated);
+
+        return createMessageResult(updated.getId(), UPDATE_ISSUE);
+    }
+
+    private  Issue createupdatedIssue(IssueUpdateDto request, Issue oldIssue, String newFileUrl) {
+        return oldIssue.toBuilder()
                 .title(request.getTitle() != null ? request.getTitle() : oldIssue.getTitle())
                 .content(request.getContent() != null ? request.getContent() : oldIssue.getContent())
                 .FileUrl(newFileUrl)
                 .milestoneId(request.getMilestoneId() != null ? request.getMilestoneId() : oldIssue.getMilestoneId())
                 .isOpen(request.getIsOpen() != null ? request.getIsOpen() : oldIssue.isOpen())
                 .build();
-
-        issueRepository.save(updated);
-
-        return createMessageResult(updated.getId(), UPDATE_ISSUE);
     }
 
     private String determineNewFileUrl(IssueUpdateDto request, String uploadUrl, Issue oldIssue) {
@@ -358,5 +362,12 @@ public class IssueService {
             foundIds.forEach(missing::remove);
             throw new AssigneeNotFoundException(missing);
         }
+    }
+
+    public void deleteIssue(Long issueId) {
+        if (!issueRepository.existsById(issueId)) {
+            throw new IssueNotFoundException(issueId);
+        }
+        issueRepository.deleteById(issueId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -60,4 +60,15 @@ public class IssueRequestDto {
     public static class IssueAssigneeUpdateDto {
         private Set<Long> assignees;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class IssueFilterParamDto {
+        private Long authorId;
+        private Long assigneeId;
+        private Long commentAuthorId;
+        @NotNull
+        private Boolean isOpen;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -1,11 +1,13 @@
 package codesquad.team4.issuetracker.issue.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Set;
 
 public class IssueRequestDto {
 
@@ -28,7 +30,9 @@ public class IssueRequestDto {
     @Getter
     @Builder
     public static class BulkUpdateIssueStatusDto {
+        @NotEmpty
         private List<Long> issuesId;
+        @NotNull
         private boolean isOpen;
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -3,13 +3,13 @@ package codesquad.team4.issuetracker.issue.dto;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
-import java.util.List;
-
 import codesquad.team4.issuetracker.user.dto.UserDto;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.util.List;
+import java.util.Set;
 
 public class IssueResponseDto {
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -1,7 +1,7 @@
 package codesquad.team4.issuetracker.issue.dto;
 
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -1,12 +1,13 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelFilter;
+import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelFilter;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +17,14 @@ public class LabelController {
 
     @GetMapping("/filter")
     public ApiResponse<LabelFilter> getFilterLabels() {
-        LabelDto.LabelFilter result = labelService.getFilterLabels();
+        LabelResponseDto.LabelFilter result = labelService.getFilterLabels();
         return ApiResponse.success(result);
+    }
+
+    @PostMapping(value = "")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createLabel(@RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
+        labelService.createLabel(request);
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -21,10 +21,24 @@ public class LabelController {
         return ApiResponse.success(result);
     }
 
-    @PostMapping(value = "")
+    @PostMapping( "")
     @ResponseStatus(HttpStatus.CREATED)
     public void createLabel(@RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
         labelService.createLabel(request);
+    }
+
+    @PutMapping("/{label-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateLabel(
+        @PathVariable("label-id") Long labelId,
+        @RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
+        labelService.updateLabel(labelId, request);
+    }
+
+    @DeleteMapping("/{label-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteLabel(@PathVariable("label-id") Long labelId) {
+        labelService.deleteLabel(labelId);
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,11 +16,11 @@ public class LabelDao {
     private final JdbcTemplate jdbcTemplate;
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-    public List<LabelDto.LabelInfo> findLabelForFiltering() {
+    public List<LabelResponseDto.LabelInfo> findLabelForFiltering() {
         String sql = "SELECT label_id, name, color FROM label";
 
         return jdbcTemplate.query(sql, (rs, rowNum) ->
-                LabelDto.LabelInfo.builder()
+                LabelResponseDto.LabelInfo.builder()
                         .id(rs.getLong("label_id"))
                         .name(rs.getString("name"))
                         .color(rs.getString("color"))

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelRepository.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.entity.Label;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LabelRepository extends CrudRepository<Label, Long> {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -1,26 +1,43 @@
 package codesquad.team4.issuetracker.label;
 
+import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
+import codesquad.team4.issuetracker.entity.Label;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class LabelService {
+    private static final String CREATE_LABEL = "레이블이 생성되었습니다";
 
     private final LabelDao labelDao;
+    private final LabelRepository labelRepository;
 
-    public LabelDto.LabelFilter getFilterLabels() {
-        List<LabelDto.LabelInfo> labels = labelDao.findLabelForFiltering();
+    public LabelResponseDto.LabelFilter getFilterLabels() {
+        List<LabelResponseDto.LabelInfo> labels = labelDao.findLabelForFiltering();
 
-        return LabelDto.LabelFilter.builder()
+        return LabelResponseDto.LabelFilter.builder()
                 .labels(labels)
                 .count(labels.size())
                 .build();
     }
+
+    @Transactional
+    public void createLabel(LabelRequestDto.CreateLabelDto request) {
+        Label label = Label.builder()
+            .name(request.getName())
+            .description(request.getDescription())
+            .color(request.getColor())
+            .build();
+
+        labelRepository.save(label);
+    }
+
+
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.label;
 
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.entity.Label;
+import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +41,25 @@ public class LabelService {
         labelRepository.save(label);
     }
 
+    @Transactional
+    public void updateLabel(Long labelId, LabelRequestDto.CreateLabelDto request) {
+        labelRepository.findById(labelId)
+            .orElseThrow(() -> new LabelNotFoundException(labelId));
 
+        Label updatedLabel = Label.builder()
+            .id(labelId)
+            .name(request.getName())
+            .description(request.getDescription())
+            .color(request.getColor())
+            .build();
+
+        labelRepository.save(updatedLabel);
+    }
+
+    @Transactional
+    public void deleteLabel(Long labelId) {
+        if (!labelRepository.existsById(labelId)) {
+            throw new LabelNotFoundException(labelId);
+        }
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelRequestDto.java
@@ -1,0 +1,19 @@
+package codesquad.team4.issuetracker.label.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class LabelRequestDto {
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class CreateLabelDto {
+        @NotBlank
+        private String name;
+        private String description;
+        @NotBlank
+        private String color;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
@@ -1,6 +1,5 @@
 package codesquad.team4.issuetracker.label.dto;
 
-import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -8,7 +7,7 @@ import lombok.Getter;
 
 import java.util.List;
 
-public class LabelDto {
+public class LabelResponseDto {
 
     @AllArgsConstructor
     @Getter
@@ -27,4 +26,5 @@ public class LabelDto {
         private List<LabelInfo> labels;
         private int count;
     }
+
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,3 +27,10 @@ cloud:
 logging:
   level:
     root: INFO
+
+springdoc:
+    api-docs:
+        path: /issue-tracker/api-docs
+    swagger-ui:
+        path: /issue-tracker/swagger-ui.html
+        url: /issue-tracker/api-docs

--- a/backend/src/test/java/codesquad/team4/issuetracker/comment/CommentServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/comment/CommentServiceTest.java
@@ -1,12 +1,5 @@
 package codesquad.team4.issuetracker.comment;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Comment;
@@ -21,6 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class CommentServiceTest {
@@ -148,6 +148,43 @@ public class CommentServiceTest {
                 commentService.updateComment(commentId, request, "dummy.png")
         ).isInstanceOf(CommentNotFoundException.class)
                 .hasMessageContaining("댓글을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void testDeleteComment_success() {
+        // given
+        Long issueId = 1L;
+        Long commentId = 2L;
+
+        Comment comment = Comment.builder()
+                .id(commentId)
+                .issueId(issueId)
+                .authorId(1L)
+                .content("삭제할 댓글.")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+        // when
+        commentService.deleteComment(issueId, commentId);
+
+        // then
+        verify(commentRepository, times(1)).findById(commentId);
+        verify(commentRepository, times(1)).deleteById(commentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글을 삭제하려 하면 에러가 발생한다")
+    void deleteNotExistComment() {
+        //given
+        Long issueId = 1L;
+        Long commentId = 999L;
+
+        //when & then
+        assertThatThrownBy(() -> commentService.deleteComment(issueId, commentId))
+                .isInstanceOf(CommentNotFoundException.class);
     }
 
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -1,7 +1,9 @@
 package codesquad.team4.issuetracker.issue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -120,5 +122,16 @@ class IssueServiceH2Test {
         assertThat(actual.getIssues().get(1).getAssignees()).hasSize(1);
         assertThat(actual.getPage()).isEqualTo(0);
         assertThat(actual.getSize()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이슈를 삭제하려 하면 에러가 발생한다")
+    void deleteNotExistIssue() {
+        //given
+        Long issueId = 999L;
+
+        //when & then
+        assertThatThrownBy(() -> issueService.deleteIssue(issueId))
+                .isInstanceOf(IssueNotFoundException.class);
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -6,21 +6,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.util.TestDataHelper;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
@@ -111,8 +111,11 @@ class IssueServiceH2Test {
         TestDataHelper.insertIssueAssignee(jdbcTemplate, 2L, 1L, 2L);
         TestDataHelper.insertIssueAssignee(jdbcTemplate, 3L, 2L, 1L);
 
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(true)
+            .build();
         //when
-        IssueResponseDto.IssueListDto actual = issueService.getIssues(true, 0, 2);
+        IssueResponseDto.IssueListDto actual = issueService.getIssues(param, 0, 2);
 
         //then
         assertThat(actual.getIssues()).hasSize(2);
@@ -133,5 +136,128 @@ class IssueServiceH2Test {
         //when & then
         assertThatThrownBy(() -> issueService.deleteIssue(issueId))
                 .isInstanceOf(IssueNotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 작성한 이슈를 가져오는 경우 다른 사람이 작성한 이슈는 가져와서는 안된다")
+    @CsvSource({
+                "true, 3, 1",
+                "false, 1, 1",
+                "true, 1, 2",
+                "false, 1, 2"})
+    void filterIssueByAuthor(boolean isOpen, int expectedSize, Long authorId) {
+        //given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .authorId(authorId)
+            .build();
+        //when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(issues.getIssues())
+            .allSatisfy(issue -> assertThat(issue.getAuthor().getId()).isEqualTo(authorId));
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 담당한 이슈를 가져오는 경우 내가 담당하지 않은 이슈는 가져와서는 안된다")
+    @CsvSource({
+        "true, 1, 1",
+        "false, 0, 1",
+        "true, 1, 2",
+        "false, 1, 2",
+        "true, 2, 3",
+        "false, 0, 3"})
+    void filterIssueByAssignee(boolean isOpen, int expectedSize, Long assigneeId) {
+        //given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertUser(jdbcTemplate, 3L, "사용자3");
+
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        //담당자 설정
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 1L, 1L, 1L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 2L, 1L, 2L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 3L, 3L, 2L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 4L, 1L, 3L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 5L, 4L, 3L);
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .assigneeId(assigneeId)
+            .build();
+        //when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(issues.getIssues())
+            .allSatisfy(issue ->
+                assertThat(issue.getAssignees().stream()
+                    .anyMatch(assignee -> assignee.getId().equals(assigneeId)))
+                    .isTrue()
+            );
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 댓글을 작성한 이슈를 가져오는 경우 댓글을 달지 않은 이슈는 가져와서는 안된다")
+    @CsvSource({
+        "true, 1, 1",
+        "false, 0, 1",
+        "true, 1, 2",
+        "false, 1, 2",
+        "true, 0, 3",
+        "false, 2, 3"
+    })
+    void filterIssueByCommentAuthor(boolean isOpen, int expectedSize, Long commentAuthorId) {
+        // given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertUser(jdbcTemplate, 3L, "사용자3");
+
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        // 댓글 작성
+        TestDataHelper.insertComment(jdbcTemplate, 1L, "댓글1", 1L, 1L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 2L, "댓글2", 2L, 2L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 3L, "댓글3", 2L, 3L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 4L, "댓글4", 3L, 3L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 5L, "댓글5", 3L, 6L, null);
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .commentAuthorId(commentAuthorId)
+            .build();
+
+        // when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //필터링한 이슈 아이디와 DB에서 조회한 이슈 아이디가 일치하는지 확인
+        List<Long> actualIssueIds = issues.getIssues().stream()
+            .map(IssueInfo::getId)
+            .toList();
+
+        String sql = """
+            SELECT DISTINCT c.issue_id
+            FROM comment c
+            JOIN issue i ON c.issue_id = i.issue_id
+            WHERE c.author_id = ?
+            AND i.is_open = ?
+        """;
+
+        List<Long> expectedIssueIds = jdbcTemplate.queryForList(sql, Long.class, commentAuthorId, isOpen);
+
+        // then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(actualIssueIds).containsExactlyInAnyOrderElementsOf(expectedIssueIds);
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -16,6 +16,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
 @ActiveProfiles("test")

--- a/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ public class LabelServiceTest {
     void setUp() {
         jdbcTemplate.update("""
             INSERT INTO label (label_id, name, color, description, created_at, updated_at)
-            VALUES 
+            VALUES
                 (1, 'bug', 'qww11', '버그 버그', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
                 (2, 'refactor', 'qq2q11', '리팩터링', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
         """);
@@ -39,7 +39,7 @@ public class LabelServiceTest {
     @DisplayName("레이블 필터링 정보 조회")
     void 레이블_필터링_정보_조회() {
         // when
-        LabelDto.LabelFilter result = labelService.getFilterLabels();
+        LabelResponseDto.LabelFilter result = labelService.getFilterLabels();
 
         // then
         assertThat(result.getLabels()).hasSize(2);

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -51,5 +51,10 @@ public class TestDataHelper {
             VALUES (?, ?, ?)
         """, id, issueId, assigneeId);
     }
-
+    public static void insertComment(JdbcTemplate jdbcTemplate, Long id, String content, Long authorId, Long issueId, String fileUrl) {
+        jdbcTemplate.update("""
+        INSERT INTO comment (comment_id, content, author_id, issue_id, file_url)
+        VALUES (?, ?, ?, ?, ?)
+    """, id, content, authorId, issueId, fileUrl);
+    }
 }


### PR DESCRIPTION
1. 작업 내용
    - 이슈 삭제 API
    - 댓글 삭제 API
    - 메인 화면 이슈 조회 필터링 API
    - getIssue리팩토링
    - 페이징 기능 버그 수정
        - 기존 코드에서는 레코드를 기준으로 페이징을 진행해서 레이블과 마일스톤을 가져 이슈가 중복되는 레코드가 생긴 경우 원하는 결과를 가져오지 못했습니다
        - 쿼리에서 limit과 offset을 처리 하는 것이 아닌 중복을 제거한 이슈 리스트에서 페이징을 하여 원하는 결과가 나오도록 수정했습니다
    - 레이블, 마일스톤 없는 경우 이슈 조회가 안되는 버그 수정
        - issue_label과 label, issue_assignee와 user를 INNER JOIN으로 바꿨는데 레이블이나 마일스톤이 없는 이슈를 가져오지 못해서 LEFT JOIN으로 수정했습니다
    - `@RestControllerAdvice` 구조 통일
    
2. 이번 주 달라진 점! 자랑할 점! 
    - (빙빙) 이슈 필터링 테스트를 작성할 떄 `@CsvSource` 를 이용하여 하나의 테스트 메소드로 여러 테스트 케이스를 검증하도록 했습니다
        
        커스텀 예외들을 각 기능에 맞는 추상 예외 클래스를 상속 받게 한 후 해당 추상 예외 클래스를 `@RestControllerAdvice` 에서 핸들링 했습니다. 다른 커스텀 예외가 더 추가 되어도 핸들링에 대한 작업이 더 줄어들거라 생각합니다
        
    - 브리) 빈 요청은 서비스에서 예외를 던지지 않고, 컨트롤러 단의 `@Valid`로 검증하여 에러로 처리했습니다.  컨틀롤러에서 입력 검증을 하고, 서비스는 비즈니스 로직에 집중 할 수 있어서 좋은 것 같습니다.

1. 앞으로 진행할 작업
    - 레이블, 마일스톤 CRUD
    - 로그인 기능

1. 기타
    - 응답으로 불필요한 메세지를 넘기지 않기 위해 `@ResponseStatus` 를 이슈 삭제 API에서 사용해 봤는데 이런식으로 상태 코드만 넘겨도 충분한지 궁금합니다