### PR TITLE
[Team-01] 3주차 PR 피드백 반영 - Kaydeen (OAuth, Label)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -38,11 +38,11 @@ out/
 
 # Spring Boot config files (all profiles)
 application*.properties
-application*.yml
-application*.yaml
 *.properties
 *.yml
 *.yaml
+/src/main/resources/properties/env.properties
+!application.yaml
 
 .DS_Store
 ._.DS_Store

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -37,12 +37,7 @@ out/
 .vscode/
 
 # Spring Boot config files (all profiles)
-application*.properties
-*.properties
-*.yml
-*.yaml
 /src/main/resources/properties/env.properties
-!application.yaml
 
 .DS_Store
 ._.DS_Store

--- a/backend/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +18,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
+@RequestMapping("/api")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
@@ -26,7 +30,7 @@ public class AuthController {
 	private final AuthorizationUrlBuilder authorizationUrlBuilder;
 
 	// Authorization endpoint
-	@GetMapping("/api/v1/oauth/github/login")
+	@GetMapping("/v1/oauth/github/login")
 	public void redirectToGithub(HttpServletResponse response, HttpSession session) throws IOException {
 		// CSRF 방지용 state 생성 및 세션 저장
 		String state = UUID.randomUUID().toString();
@@ -39,7 +43,7 @@ public class AuthController {
 	}
 
 	// Redirect(Callback) endpoint
-	@GetMapping("/api/v1/oauth/callback")
+	@GetMapping("/v1/oauth/callback")
 	public AuthDto.LoginResponse githubCallback(
 		@RequestParam("code") String code,
 		@RequestParam("state") String state,
@@ -55,7 +59,7 @@ public class AuthController {
 
 	//자체 로그인
 	//에러 발생 시 API Response 적용 예정
-	@PostMapping("/api/v1/auth/login")
+	@PostMapping("/v1/auth/login")
 	public AuthDto.LoginResponse login(@RequestBody @Valid AuthDto.LoginRequest request) {
 		return authService.login(request.loginId(), request.password());
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
@@ -35,7 +35,7 @@ public class GitHubClient {
 
 	// token 요청
 	public String fetchAccessToken(String code) {
-		log.info("Requesting access token from GitHub for code={}", code);
+		log.info("해당 인증 코드 ({}) 로 GitHub 에 access token 요청", code);
 		Map<String, String> tokenRequest = Map.of(
 			CLIENT_ID, properties.getClientId(),
 			CLIENT_SECRET, properties.getClientSecret(),
@@ -51,13 +51,13 @@ public class GitHubClient {
 			properties.getTokenUri(), request, Map.class
 		);
 		String token = (String)tokenResponse.getBody().get(ACCESS_TOKEN);
-		log.info("GitHub access token fetched");
+		log.info("GitHub access token 가져오기 완료");
 		return token;
 	}
 
 	// 사용자 정보 요청
 	public AuthDto.GitHubUser fetchUserInfo(String accessToken) {
-		log.info("Fetching GitHub user info with accessToken");
+		log.info("access token 을 사용한 GitHub 사용자 정보 요청");
 		HttpHeaders authHeaders = new HttpHeaders();
 		authHeaders.setBearerAuth((accessToken));
 		HttpEntity<Void> userRequest = new HttpEntity<>(authHeaders);
@@ -67,7 +67,6 @@ public class GitHubClient {
 		);
 
 		Map<String, Object> userMap = userResponse.getBody();
-		log.debug("GitHub user info response: {}", userMap);
 		Long id = ((Number)userMap.get(ID)).longValue();
 		String githubId = (String)userMap.get(LOGIN);
 		String avatarUrl = (String)userMap.get(AVATAR_URL);
@@ -83,7 +82,7 @@ public class GitHubClient {
 				.orElse(null);
 		}
 
-		log.info("GitHubUser parsed: id={}, login={}", id, githubId);
+		log.info("GitHub 사용자 정보 : id={}, login={}, avatarUrl={}, email={}", id, githubId, avatarUrl, email);
 		return new AuthDto.GitHubUser(id, githubId, avatarUrl, email);
 	}
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
@@ -73,7 +73,7 @@ public class GitHubClient {
 
 		String email = (String)userMap.get("email");
 		if (email == null) {
-			var emails = fetchUserEmail(accessToken);
+			List<AuthDto.GitHubEmail> emails = fetchUserEmail(accessToken);
 			email = emails.stream()
 				.filter(AuthDto.GitHubEmail::primary)
 				.filter(AuthDto.GitHubEmail::verified)

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/repository/RefreshTokenRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/repository/RefreshTokenRepository.java
@@ -3,11 +3,9 @@ package codesquad.team01.issuetracker.auth.repository;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 import codesquad.team01.issuetracker.auth.domain.RefreshToken;
 
-@Repository
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Integer> {
 
 	Optional<RefreshToken> findByUserId(Integer userId);

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
@@ -2,11 +2,9 @@ package codesquad.team01.issuetracker.auth.service;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import codesquad.team01.issuetracker.auth.client.GitHubClient;
 import codesquad.team01.issuetracker.auth.dto.AuthDto;
-import codesquad.team01.issuetracker.common.config.GithubOAuthProperties;
 import codesquad.team01.issuetracker.user.domain.User;
 import codesquad.team01.issuetracker.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +17,6 @@ public class AuthService {
 
 	private final GitHubClient gitHubClient;
 	private final UserRepository userRepository;
-	private final GithubOAuthProperties properties;
-	private final RestTemplate restTemplate;
 
 	private final String GITHUB = "github";
 	private final TokenService tokenService;
@@ -28,16 +24,16 @@ public class AuthService {
 
 	public AuthDto.LoginResponse loginWithGitHub(String code) {
 		// 깃헙에 access token 요청
-		log.info("Starting GitHub login flow with code={}", code);
+		log.info("GitHub 에서 받은 인증 코드로 로그인 시작 ={}", code);
 		String accessToken = gitHubClient.fetchAccessToken(code);
 
 		// 사용자 정보 요청
 		log.debug("Received access token");
 		AuthDto.GitHubUser gitHubUser = gitHubClient.fetchUserInfo(accessToken);
-		log.info("Fetched user info: id={}, githubId={}", gitHubUser.id(), gitHubUser.githubId());
+		log.info("사용자 정보 요청 : id={}, githubId={}", gitHubUser.id(), gitHubUser.githubId());
 
 		User oauthUser = findOrCreateUser(gitHubUser);
-		log.info("Created LoginResponse for userId={}", oauthUser.getId());
+		log.info("사용자 id로 로그인 응답 생성 ={}", oauthUser.getId());
 
 		AuthDto.LoginResponse response = createJwtToken(oauthUser.getId(),
 			oauthUser.getProfileImageUrl(),

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/service/AuthService.java
@@ -25,14 +25,6 @@ public class AuthService {
 	private final String GITHUB = "github";
 	private final TokenService tokenService;
 	private final PasswordEncoder passwordEncoder;
-	private final String CLIENT_ID = "client_id";
-	private final String CLIENT_SECRET = "client_secret";
-	private final String AUTHORIZATION_CODE = "code";
-	private final String REDIRECT_URI = "redirect_uri";
-	private final String ID = "id";
-	private final String LOGIN = "login";
-	private final String AVATAR_URL = "avatar_url";
-	private final String ACCESS_TOKEN = "access_token";
 
 	public AuthDto.LoginResponse loginWithGitHub(String code) {
 		// 깃헙에 access token 요청

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/WebConfig.java
@@ -1,0 +1,16 @@
+package codesquad.team01.issuetracker.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("api/**")
+			.allowedOrigins("http://localhost:3000")
+			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+			.allowCredentials(true);
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/api/IssueController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/api/IssueController.java
@@ -14,13 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RestController
 public class IssueController {
 
 	private final IssueService issueService;
 
-	@GetMapping("/issues")
+	@GetMapping("/v1/issues")
 	public ResponseEntity<ApiResponse<IssueDto.ListResponse>> getIssues(
 		@Valid IssueDto.ListQueryRequest request) {
 
@@ -42,7 +42,7 @@ public class IssueController {
 		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 
-	@GetMapping("/issues/count")
+	@GetMapping("/v1/issues/count")
 	public ResponseEntity<ApiResponse<IssueDto.CountResponse>> getIssuesCount(
 		@Valid IssueDto.CountQueryRequest request) {
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
@@ -123,7 +123,7 @@ public class IssueDto {
 		private final List<UserDto.AssigneeResponse> assignees = new ArrayList<>();
 
 		@Builder.Default
-		private final List<LabelDto.ListItemResponse> labels = new ArrayList<>();
+		private final List<LabelDto.FilterListItemResponse> labels = new ArrayList<>();
 	}
 
 	@Builder
@@ -184,7 +184,7 @@ public class IssueDto {
 	public record Details(
 		BaseRow baseInfo,
 		List<UserDto.AssigneeResponse> assignees,
-		List<LabelDto.ListItemResponse> labels
+		List<LabelDto.FilterListItemResponse> labels
 	) {
 		public ListItemResponse toListItemResponse() { // Mapper 클래스로 따로 뺄지 고민
 			return IssueDto.ListItemResponse.builder()

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
@@ -38,7 +38,7 @@ public class IssueDto {
 	@Builder
 	public record CountQueryRequest(
 		@Positive(message = "작성자 ID는 양수여야 합니다")
-		Integer writerId,
+		int writerId,
 
 		@Positive(message = "마일스톤 ID는 양수여야 합니다")
 		Integer milestoneId,
@@ -56,7 +56,7 @@ public class IssueDto {
 		String state,
 
 		@Positive(message = "작성자 ID는 양수여야 합니다")
-		Integer writerId,
+		int writerId,
 
 		@Positive(message = "마일스톤 ID는 양수여야 합니다")
 		Integer milestoneId,
@@ -110,7 +110,7 @@ public class IssueDto {
 	@Getter
 	@Builder
 	public static class ListItemResponse {
-		private final Integer id;
+		private final int id;
 
 		private final String title;
 		private final String state;
@@ -148,7 +148,7 @@ public class IssueDto {
 	@Builder
 	public record BaseRow(
 		// issue
-		Integer issueId,
+		int issueId,
 
 		String issueTitle,
 		IssueState issueState,
@@ -156,7 +156,7 @@ public class IssueDto {
 		LocalDateTime issueUpdatedAt,
 
 		// writerId
-		Integer writerId,
+		int writerId,
 
 		String writerUsername,
 		String writerProfileImageUrl,
@@ -216,7 +216,7 @@ public class IssueDto {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class CursorData {
-		private Integer id;
+		private int id;
 		private LocalDateTime createdAt;
 
 		public String encode() {

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
@@ -216,7 +216,7 @@ public class IssueDto {
 	@AllArgsConstructor
 	@NoArgsConstructor
 	public static class CursorData {
-		private int id;
+		private Integer id;
 		private LocalDateTime createdAt;
 
 		public String encode() {

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/dto/IssueDto.java
@@ -38,7 +38,7 @@ public class IssueDto {
 	@Builder
 	public record CountQueryRequest(
 		@Positive(message = "작성자 ID는 양수여야 합니다")
-		int writerId,
+		Integer writerId,
 
 		@Positive(message = "마일스톤 ID는 양수여야 합니다")
 		Integer milestoneId,
@@ -56,7 +56,7 @@ public class IssueDto {
 		String state,
 
 		@Positive(message = "작성자 ID는 양수여야 합니다")
-		int writerId,
+		Integer writerId,
 
 		@Positive(message = "마일스톤 ID는 양수여야 합니다")
 		Integer milestoneId,

--- a/backend/src/main/java/codesquad/team01/issuetracker/issue/service/IssueAssembler.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/issue/service/IssueAssembler.java
@@ -27,7 +27,7 @@ public class IssueAssembler {
 		log.debug("이슈별 담당자 정보 그룹화: {}개 이슈-담당자 매핑", assigneesByIssueId.size());
 
 		// 레이블 정보를 이슈 id로 그룹화
-		Map<Integer, List<LabelDto.ListItemResponse>> labelsByIssueId = groupLabelsByIssueId(labels);
+		Map<Integer, List<LabelDto.FilterListItemResponse>> labelsByIssueId = groupLabelsByIssueId(labels);
 
 		log.debug("이슈별 레이블 정보 그룹화: {}개 이슈-레이블 매핑", labelsByIssueId.size());
 
@@ -59,13 +59,14 @@ public class IssueAssembler {
 	}
 
 	// 레이블 정보 이슈 id로 그룹화
-	private Map<Integer, List<LabelDto.ListItemResponse>> groupLabelsByIssueId(List<LabelDto.IssueLabelRow> labels) {
+	private Map<Integer, List<LabelDto.FilterListItemResponse>> groupLabelsByIssueId(
+		List<LabelDto.IssueLabelRow> labels) {
 
 		return labels.stream()
 			.collect(Collectors.groupingBy(
 				LabelDto.IssueLabelRow::issueId,
 				Collectors.mapping(
-					row -> LabelDto.ListItemResponse.builder()
+					row -> LabelDto.FilterListItemResponse.builder()
 						.id(row.labelId())
 						.name(row.labelName())
 						.color(row.labelColor())

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
@@ -19,13 +19,13 @@ public class LabelController {
 
 	private final LabelService labelService;
 
-	@GetMapping("/v1/labels")
+	@GetMapping("/v1/labels/list")
 	public ResponseEntity<ApiResponse<LabelDto.ListResponse>> getLabels() {
 		LabelDto.ListResponse listResponse = labelService.getLabels();
 		return ResponseEntity.ok(ApiResponse.success(listResponse));
 	}
 
-	@GetMapping("/v1/filters/labels")
+	@GetMapping("/v1/labels/filters")
 	public ResponseEntity<ApiResponse<LabelDto.LabelFilterListResponse>> getLabelFilter() {
 		LabelDto.LabelFilterListResponse response = labelService.findLabelsForFilter();
 		log.info("레이블 목록 개수= {}", response.totalCount());

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
@@ -19,7 +19,7 @@ public class LabelController {
 
 	private final LabelService labelService;
 
-	@GetMapping("/v1/labels/list")
+	@GetMapping("/v1/labels")
 	public ResponseEntity<ApiResponse<LabelDto.ListResponse>> getLabels() {
 		LabelDto.ListResponse listResponse = labelService.getLabels();
 		return ResponseEntity.ok(ApiResponse.success(listResponse));

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
@@ -2,7 +2,9 @@ package codesquad.team01.issuetracker.label.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
 @RequiredArgsConstructor
 public enum LabelTextColor {
@@ -20,6 +22,7 @@ public enum LabelTextColor {
 		try {
 			return valueOf(textColor.toUpperCase());
 		} catch (IllegalArgumentException e) {
+			log.debug("지원하지 않는 색상 값 '{}'이(가 전달되어 기본 색상 BLACK(#000000)으로 설정되었습니다.", textColor);
 			return BLACK; // 기본값
 		}
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -16,7 +16,7 @@ public class LabelDto {
 	// 이슈 목록 - 레이블 응답 DTO
 	@Builder
 	public record ListItemResponse(
-		Integer id,
+		int id,
 		String name,
 		String description,
 		String color,
@@ -33,8 +33,8 @@ public class LabelDto {
 	// 이슈 레이블 행 DTO
 	@Builder
 	public record IssueLabelRow(
-		Integer issueId,
-		Integer labelId,
+		int issueId,
+		int labelId,
 		String labelName,
 		String labelColor,
 		LabelTextColor labelTextColor
@@ -43,8 +43,7 @@ public class LabelDto {
 
 	@Builder
 	public record LabelFilterResponse(
-		Integer id,
-
+		int id,
 		String name,
 		String color
 	) {
@@ -58,7 +57,7 @@ public class LabelDto {
 	}
 
 	public record LabelListItem(
-		Integer id,
+		int id,
 		String name,
 		String description,
 		String color,

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -1,6 +1,5 @@
 package codesquad.team01.issuetracker.label.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import codesquad.team01.issuetracker.label.domain.LabelTextColor;
@@ -14,6 +13,15 @@ public class LabelDto {
 	 * 응답 DTO
 	 */
 	// 이슈 목록 - 레이블 응답 DTO
+	@Builder
+	public record FilterListItemResponse(
+		int id,
+		String name,
+		String color,
+		String textColor
+	) {
+	}
+
 	@Builder
 	public record ListItemResponse(
 		int id,
@@ -56,14 +64,12 @@ public class LabelDto {
 	) {
 	}
 
-	public record LabelListItem(
+	public record LabelRow(
 		int id,
 		String name,
 		String description,
 		String color,
-		String textColor,
-		LocalDateTime createdAt,
-		LocalDateTime updatedAt
+		String textColor
 	) {
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -30,6 +30,15 @@ public class LabelDto {
 		String color,
 		String textColor
 	) {
+		public static ListItemResponse from(LabelRow row) {
+			return new ListItemResponse(
+				row.id(),
+				row.name(),
+				row.description(),
+				row.color(),
+				row.textColor()
+			);
+		}
 	}
 
 	public record ListResponse(

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
@@ -4,12 +4,10 @@ import java.util.List;
 
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 import codesquad.team01.issuetracker.label.domain.Label;
 import codesquad.team01.issuetracker.label.dto.LabelDto;
 
-@Repository
 public interface LabelRepository extends CrudRepository<Label, Integer> {
 	@Query("""
 		SELECT 

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
@@ -21,5 +21,5 @@ public interface LabelRepository extends CrudRepository<Label, Integer> {
 		FROM label
 		WHERE deleted_at IS NULL
 		""")
-	List<LabelDto.ListItemResponse> findLabels();
+	List<LabelDto.LabelRow> findLabels();
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -1,6 +1,7 @@
 package codesquad.team01.issuetracker.label.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
@@ -17,8 +18,21 @@ public class LabelService {
 	private final LabelQueryRepository labelQueryRepository;
 
 	public LabelDto.ListResponse getLabels() {
-		List<LabelDto.ListItemResponse> items = labelRepository.findLabels();
+		List<LabelDto.ListItemResponse> items = labelRepository.findLabels()
+			.stream()
+			.map(this::toListItemResponse)
+			.collect(Collectors.toList());
 		return new LabelDto.ListResponse(items.size(), items);
+	}
+
+	private LabelDto.ListItemResponse toListItemResponse(LabelDto.LabelRow row) {
+		return LabelDto.ListItemResponse.builder()
+			.id(row.id())
+			.name(row.name())
+			.description(row.description())
+			.color(row.color())
+			.textColor(row.textColor())
+			.build();
 	}
 
 	public LabelDto.LabelFilterListResponse findLabelsForFilter() {

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -20,19 +20,9 @@ public class LabelService {
 	public LabelDto.ListResponse getLabels() {
 		List<LabelDto.ListItemResponse> items = labelRepository.findLabels()
 			.stream()
-			.map(this::toListItemResponse)
+			.map(LabelDto.ListItemResponse::from)
 			.collect(Collectors.toList());
 		return new LabelDto.ListResponse(items.size(), items);
-	}
-
-	private LabelDto.ListItemResponse toListItemResponse(LabelDto.LabelRow row) {
-		return LabelDto.ListItemResponse.builder()
-			.id(row.id())
-			.name(row.name())
-			.description(row.description())
-			.color(row.color())
-			.textColor(row.textColor())
-			.build();
 	}
 
 	public LabelDto.LabelFilterListResponse findLabelsForFilter() {

--- a/backend/src/main/java/codesquad/team01/issuetracker/milestone/api/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/milestone/api/MilestoneController.java
@@ -19,7 +19,7 @@ public class MilestoneController {
 
 	private final MilestoneService milestoneService;
 
-	@GetMapping("/v1/filters/milestones")
+	@GetMapping("/v1/milestones/filters")
 	public ResponseEntity<ApiResponse<MilestoneDto.MilestoneFilterListResponse>> getMilestones() {
 		MilestoneDto.MilestoneFilterListResponse response = milestoneService.findMilestonesForFilter();
 		log.info("마일스톤 목록 개수= {}", response.totalCount());

--- a/backend/src/main/java/codesquad/team01/issuetracker/milestone/api/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/milestone/api/MilestoneController.java
@@ -12,14 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @RestController
 public class MilestoneController {
 
 	private final MilestoneService milestoneService;
 
-	@GetMapping("/filters/milestones")
+	@GetMapping("/v1/filters/milestones")
 	public ResponseEntity<ApiResponse<MilestoneDto.MilestoneFilterListResponse>> getMilestones() {
 		MilestoneDto.MilestoneFilterListResponse response = milestoneService.findMilestonesForFilter();
 		log.info("마일스톤 목록 개수= {}", response.totalCount());

--- a/backend/src/main/java/codesquad/team01/issuetracker/milestone/dto/MilestoneDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/milestone/dto/MilestoneDto.java
@@ -8,22 +8,20 @@ public class MilestoneDto {
 	private MilestoneDto() {
 	}
 
-	/**
+	/*
 	 * 응답 DTO
 	 */
 	// 이슈 목록 - 마일스톤 응답 DTO
 	@Builder
 	public record ListItemResponse(
-		Integer id,
-
+		int id,
 		String title
 	) {
 	}
 
 	@Builder
 	public record MilestoneFilterResponse(
-		Integer id,
-
+		int id,
 		String title
 	) {
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/user/api/UserController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/user/api/UserController.java
@@ -13,13 +13,13 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RestController
 public class UserController {
 
 	private final UserService userService;
 
-	@GetMapping("/filters/users")
+	@GetMapping("/v1/filters/users")
 	public ResponseEntity<ApiResponse<UserDto.UserFilterListResponse>> getUsers() {
 		UserDto.UserFilterListResponse response = userService.findUsersForFilter();
 		log.info("사용자 목록 개수= {}", response.totalCount());

--- a/backend/src/main/java/codesquad/team01/issuetracker/user/api/UserController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/user/api/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
 
 	private final UserService userService;
 
-	@GetMapping("/v1/filters/users")
+	@GetMapping("/v1/users/filters")
 	public ResponseEntity<ApiResponse<UserDto.UserFilterListResponse>> getUsers() {
 		UserDto.UserFilterListResponse response = userService.findUsersForFilter();
 		log.info("사용자 목록 개수= {}", response.totalCount());

--- a/backend/src/main/java/codesquad/team01/issuetracker/user/dto/UserDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/user/dto/UserDto.java
@@ -20,8 +20,7 @@ public class UserDto {
 		// 처음엔 작성자 응답 DTO로 생성했지만
 		// 현재 담당자, 작성자 필터 db 조회용 dto, 응답용 dto의 역할도 하고 있음
 		// 이럴 경우 더 만들지? 이름을 범용적으로 바꿀지?
-		Integer id,
-
+		int id,
 		String username,
 		String profileImageUrl
 	) {
@@ -33,8 +32,7 @@ public class UserDto {
 	// 담당자 응답 DTO
 	@Builder
 	public record AssigneeResponse(
-		Integer id,
-
+		int id,
 		String profileImageUrl
 	) {
 		public String profileImageUrl() {
@@ -46,7 +44,6 @@ public class UserDto {
 	public record UserFilterListResponse(
 		int totalCount,
 		List<WriterResponse> users // WriterResponse와 같이 데이터를 필요로 해서 임시로 넣음
-
 	) {
 	}
 
@@ -56,9 +53,8 @@ public class UserDto {
 	// 이슈 담당자 행 DTO
 	@Builder
 	public record IssueAssigneeRow(
-		Integer issueId,
-		Integer assigneeId,
-
+		int issueId,
+		int assigneeId,
 		String assigneeProfileImageUrl
 	) {
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/user/repository/UserRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ import codesquad.team01.issuetracker.user.domain.User;
 
 @Repository
 public interface UserRepository extends CrudRepository<User, Integer> {
-	Optional<User> findByLoginId(String id);
+	Optional<User> findByLoginId(String loginId);
 
 	Optional<User> findByProviderIdAndAuthProvider(Long providerId, String authProvider);
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/user/repository/UserRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/user/repository/UserRepository.java
@@ -3,11 +3,9 @@ package codesquad.team01.issuetracker.user.repository;
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 import codesquad.team01.issuetracker.user.domain.User;
 
-@Repository
 public interface UserRepository extends CrudRepository<User, Integer> {
 	Optional<User> findByLoginId(String loginId);
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: backend
+
+  config:
+    import: optional:classpath:properties/env.properties
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+
+  sql:
+    init:
+      mode: never
+      schema-locations: classpath:schema.sql
+
+github:
+  oauth:
+    client-id: ${GITHUB_CLIENT_ID}
+    client-secret: ${GITHUB_CLIENT_SECRET}
+    authorize-uri: https://github.com/login/oauth/authorize
+    token-uri: https://github.com/login/oauth/access_token
+    user-info-uri: https://api.github.com/user
+    user-email-uri: https://api.github.com/user/emails
+    redirect-uri: http://localhost:8080/api/v1/oauth/callback
+    scope: read:user user:email
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY}
+  refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY}


### PR DESCRIPTION
## 피드백

![image](https://github.com/user-attachments/assets/c83d5e46-6baf-4c7d-9fea-e4d7ea5aacec)

## 답변

스프링이 제공하는 외부 설정 방식을 공부해봤습니다. 결과로 application.yaml 파일에는 민감 정보를 직접 쓰지 않고 플레이스 홀더만 남겨 두고, 별도의 프로퍼티 파일(env.properties)에서 실제 값들을 관리하고 클래스패스에서 로드하도록 설정했습니다. env 파일을 .gitignore로 관리합니다.

로컬 실행 시에는 src/main/resources/properties/env.properties로 값들이 채워지고, ci/cd나 운영 환경에서는 같은 이름으로 등록된 환경 변수(예를 들어 깃헙 시크릿)으로 대체하는 방식으로 구현했습니다.


<br>

## 피드백

![image](https://github.com/user-attachments/assets/b6b168e2-610e-45a1-816d-3f8d147e0d7c)

## 답변

삭제한 상수들이지만 서로 코드를 머지하는 과정에서 되살아난 부분 같습니다. 앞으로 머지 시에 유의하겠습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/49708f57-9971-4a96-b057-cbf25e1db806)

## 답변

컨트롤러마다 @RequestMapping("/api")로 통일했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/17536e57-473d-413d-8e72-da563c083254)

## 답변

CrudRepository를 상속한 레포지토리에는 @Repository 어노테이션을 제거했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/9fc890e5-02ac-41a8-b997-276ba393a874)

## 답변

옙 로그 출력하도록 했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/379709f5-7ab3-4d35-abc5-755445ea1053)

## 답변

DTO에서 id값이 null이 아닌 게 확실한 부분은 타입을 int로 수정했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/4ef200b5-1bd6-4d0f-b140-27da6585da7f)

## 답변

각 엔드포인트에서 해당 리소스(issue, label, milestone 등)가 부가적인 기능을 표현하는 단어보다 앞에 오도록 수정했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/a50c90d3-a8aa-4ff6-ac83-cc622171cd70)

## 답변

넵 파라미터 이름을 pk 칼럼명과 중복되지 않도록 수정했습니다.

<br>

## 피드백

![image](https://github.com/user-attachments/assets/1c233324-16b3-4fec-a32a-e2abad4bdaca)

## 답변

저도 생각해봤는데, 이후에 DB에서 조회해 올 데이터가 추가될 가능성을 생각하면 현재 데이터가 동일해도 dto를 분리하는게 당연할 것 같습니다. 상세히 답변해주셔서 감사합니다!
