### PR TITLE
[Team-01] 4주차 PR - Kaydeen (Label)

### DIFF
--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/client/GitHubClient.java
@@ -82,7 +82,7 @@ public class GitHubClient {
 				.orElse(null);
 		}
 
-		log.info("GitHub 사용자 정보 : id={}, login={}, avatarUrl={}, email={}", id, githubId, avatarUrl, email);
+		log.info("GitHub 사용자 정보 : id={}, login={}, avatarUrl={}", id, githubId, avatarUrl);
 		return new AuthDto.GitHubUser(id, githubId, avatarUrl, email);
 	}
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
@@ -1,0 +1,7 @@
+package codesquad.team01.issuetracker.common.exception;
+
+public class DuplicateLabelName extends RuntimeException {
+	public DuplicateLabelName(String message) {
+		super(message);
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
@@ -5,7 +5,7 @@ public class DuplicateLabelName extends RuntimeException {
 	private final String labelName;
 
 	public DuplicateLabelName(String labelName) {
-		super("중복된 레이블 이름 : " + labelName);
+		super(labelName);
 		this.labelName = labelName;
 	}
 

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/DuplicateLabelName.java
@@ -1,7 +1,15 @@
 package codesquad.team01.issuetracker.common.exception;
 
 public class DuplicateLabelName extends RuntimeException {
-	public DuplicateLabelName(String message) {
-		super(message);
+
+	private final String labelName;
+
+	public DuplicateLabelName(String labelName) {
+		super("중복된 레이블 이름 : " + labelName);
+		this.labelName = labelName;
+	}
+
+	public String getLabelName() {
+		return labelName;
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
@@ -33,12 +33,22 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(errorMessage));
 	}
 
-	@ExceptionHandler(DuplicateLabelName.class)    // 레이블 생성 시 이미 생성된 레이블과 이름 중복
+	// 레이블 생성 시 이미 존재하는 레이블과 이름 중복
+	@ExceptionHandler(DuplicateLabelName.class)
 	public ResponseEntity<ApiResponse<?>> handleDuplicateLabel(DuplicateLabelName e) {
 		String labelName = e.getLabelName();
 		return ResponseEntity
 			.badRequest()
 			.body(ApiResponse.error("레이블 이름 '" + labelName + "'은(는) 이미 존재합니다."));
+	}
+	
+	// 레이블을 찾을 수 없을 때
+	@ExceptionHandler(LabelNotFoundException.class)
+	public ResponseEntity<ApiResponse<?>> handleLabelNotFound(LabelNotFoundException e) {
+		String labelName = e.getLabelName();
+		return ResponseEntity
+			.badRequest()
+			.body(ApiResponse.error("레이블 '" + labelName + "' 을(를) 찾을 수 없습니다."));
 	}
 
 	@ExceptionHandler(Exception.class)
@@ -60,5 +70,4 @@ public class GlobalExceptionHandler {
 		log.error("InvalidPasswordException : {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("비밀번호가 일치하지 않습니다"));
 	}
-
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
@@ -41,14 +41,14 @@ public class GlobalExceptionHandler {
 			.badRequest()
 			.body(ApiResponse.error("레이블 이름 '" + labelName + "'은(는) 이미 존재합니다."));
 	}
-	
+
 	// 레이블을 찾을 수 없을 때
 	@ExceptionHandler(LabelNotFoundException.class)
 	public ResponseEntity<ApiResponse<?>> handleLabelNotFound(LabelNotFoundException e) {
-		String labelName = e.getLabelName();
+		int id = e.getId();
 		return ResponseEntity
 			.badRequest()
-			.body(ApiResponse.error("레이블 '" + labelName + "' 을(를) 찾을 수 없습니다."));
+			.body(ApiResponse.error("레이블 '" + id + "' 을(를) 찾을 수 없습니다."));
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
@@ -33,6 +33,14 @@ public class GlobalExceptionHandler {
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error(errorMessage));
 	}
 
+	@ExceptionHandler(DuplicateLabelName.class)    // 레이블 생성 시 이미 생성된 레이블과 이름 중복
+	public ResponseEntity<ApiResponse<?>> handleDuplicateLabel(DuplicateLabelName e) {
+		String labelName = e.getLabelName();
+		return ResponseEntity
+			.badRequest()
+			.body(ApiResponse.error("레이블 이름 '" + labelName + "'은(는) 이미 존재합니다."));
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ApiResponse<?>> handleExceptions(Exception e) {
 		log.error("Unhandled exception", e);

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
@@ -2,10 +2,14 @@ package codesquad.team01.issuetracker.common.exception;
 
 public class LabelNotFoundException extends RuntimeException {
 
-	private final String name;
+	private final String labelName;
 
-	public LabelNotFoundException(String name) {
-		super("'" + name + "' 레이블을 찾을 수 없습니다.");
-		this.name = name;
+	public LabelNotFoundException(String labelName) {
+		super(labelName);
+		this.labelName = labelName;
+	}
+
+	public String getLabelName() {
+		return labelName;
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
@@ -1,0 +1,11 @@
+package codesquad.team01.issuetracker.common.exception;
+
+public class LabelNotFoundException extends RuntimeException {
+
+	private final String name;
+
+	public LabelNotFoundException(String name) {
+		super("'" + name + "' 레이블을 찾을 수 없습니다.");
+		this.name = name;
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/LabelNotFoundException.java
@@ -2,14 +2,14 @@ package codesquad.team01.issuetracker.common.exception;
 
 public class LabelNotFoundException extends RuntimeException {
 
-	private final String labelName;
+	private final int id;
 
-	public LabelNotFoundException(String labelName) {
-		super(labelName);
-		this.labelName = labelName;
+	public LabelNotFoundException(int id) {
+		super(id + "를 찾을 수 없습니다.");
+		this.id = id;
 	}
 
-	public String getLabelName() {
-		return labelName;
+	public int getId() {
+		return id;
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
@@ -4,7 +4,9 @@ import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,13 @@ public class LabelController {
 		return ResponseEntity
 			.created(URI.create("/api/v1/labels" + response.id()))
 			.body(ApiResponse.success(response));
+	}
+
+	@PutMapping("/v1/labels/{id}")
+	public ResponseEntity<ApiResponse<LabelDto.LabelUpdateResponse>> updateLabel(@PathVariable("id") int id,
+		@Valid @RequestBody LabelDto.LabelUpdateRequest request) {
+		LabelDto.LabelUpdateResponse response = labelService.updateLabel(id, request);
+		log.info("레이블 수정 완료: name={}", response.name());
+		return ResponseEntity.ok(ApiResponse.success(response));
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
@@ -3,6 +3,7 @@ package codesquad.team01.issuetracker.label.api;
 import java.net.URI;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,5 +56,12 @@ public class LabelController {
 		LabelDto.LabelUpdateResponse response = labelService.updateLabel(id, request);
 		log.info("레이블 수정 완료: name={}", response.name());
 		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@DeleteMapping("/v1/labels/{id}")
+	public ResponseEntity<ApiResponse<Void>> deleteLabel(@PathVariable("id") int id) {
+		labelService.deleteLabel(id);
+		log.info("레이블 삭제 완료: id={}", id);
+		return ResponseEntity.ok(ApiResponse.success(null));
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/api/LabelController.java
@@ -1,13 +1,18 @@
 package codesquad.team01.issuetracker.label.api;
 
+import java.net.URI;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.team01.issuetracker.common.dto.ApiResponse;
 import codesquad.team01.issuetracker.label.dto.LabelDto;
 import codesquad.team01.issuetracker.label.service.LabelService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,5 +35,15 @@ public class LabelController {
 		LabelDto.LabelFilterListResponse response = labelService.findLabelsForFilter();
 		log.info("레이블 목록 개수= {}", response.totalCount());
 		return ResponseEntity.ok(ApiResponse.success(response));
+	}
+
+	@PostMapping("/v1/labels")
+	public ResponseEntity<ApiResponse<LabelDto.LabelCreateResponse>> createLabel(
+		@Valid @RequestBody LabelDto.LabelCreateRequest request) {
+		LabelDto.LabelCreateResponse response = labelService.saveLabel(request);
+		log.info("레이블 생성 완료: name={}", response.name());
+		return ResponseEntity
+			.created(URI.create("/api/v1/labels" + response.id()))
+			.body(ApiResponse.success(response));
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/domain/Label.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/domain/Label.java
@@ -32,4 +32,11 @@ public class Label extends BaseEntity {
 		this.color = color;
 		this.textColor = textColor;
 	}
+
+	public void update(String name, String description, String color, String textColor) {
+		this.name = name;
+		this.description = description;
+		this.color = color;
+		this.textColor = textColor;
+	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
@@ -18,7 +18,7 @@ public enum LabelTextColor {
 		try {
 			return valueOf(textColor.toUpperCase());
 		} catch (IllegalArgumentException e) {
-			log.debug("지원하지 않는 색상 값 '{}'이(가 전달되어 기본 색상 BLACK(#000000)으로 설정되었습니다.", textColor);
+			log.warn("지원하지 않는 색상 값 '{}'이(가 전달되어 기본 색상 BLACK(#000000)으로 설정되었습니다.", textColor);
 			return BLACK; // 기본값
 		}
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/domain/LabelTextColor.java
@@ -1,18 +1,14 @@
 package codesquad.team01.issuetracker.label.domain;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Getter
-@RequiredArgsConstructor
 public enum LabelTextColor {
 
-	BLACK("#000000"),
-	WHITE("#FFFFFF");
-
-	private final String hexCode;
+	BLACK,
+	WHITE;
 
 	public static LabelTextColor fromTextColorStr(String textColor) {
 		if (textColor == null) {

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -26,6 +26,7 @@ public class LabelDto {
 	) {
 	}
 
+	// 레이블 리스트를 구성하는 레이블
 	@Builder
 	public record ListItemResponse(
 		int id,
@@ -45,6 +46,7 @@ public class LabelDto {
 		}
 	}
 
+	// 레이블 목록 조회 시 반환하는 레이블 리스트
 	public record ListResponse(
 		int totalCount,
 		List<ListItemResponse> labels

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -136,4 +136,48 @@ public class LabelDto {
 			);
 		}
 	}
+
+	// 레이블 수정 요청 dto
+	public record LabelUpdateRequest(
+		int id,
+
+		@NotBlank(message = "Label 이름은 필수입니다.")
+		@Size(max = 100, message = "Label 이름은 최대 100자 이내여야 합니다.")
+		String name,
+		String description,
+
+		@NotBlank(message = "배경색은 필수입니다.")
+		@Pattern(
+			regexp = "^#([0-9A-Fa-f]{6})$",
+			message = "색상은 #RRGGBB 형식이어야 합니다."
+		)
+		String color,
+
+		@NotBlank(message = "글자색은 필수입니다.")
+		@Pattern(
+			regexp = "^(WHITE|BLACK)$",
+			message = "글자 색은 WHITE 또는 BLACK 만 가능합니다."
+		)
+		String textColor
+	) {
+	}
+
+	// 레이블 수정 응답 dto
+	public record LabelUpdateResponse(
+		int id,
+		String name,
+		String description,
+		String color,
+		String textColor
+	) {
+		public static LabelUpdateResponse from(Label label) {
+			return new LabelUpdateResponse(
+				label.getId(),
+				label.getName(),
+				label.getDescription(),
+				label.getColor(),
+				label.getTextColor()
+			);
+		}
+	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -2,7 +2,11 @@ package codesquad.team01.issuetracker.label.dto;
 
 import java.util.List;
 
+import codesquad.team01.issuetracker.label.domain.Label;
 import codesquad.team01.issuetracker.label.domain.LabelTextColor;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
 public class LabelDto {
@@ -76,6 +80,7 @@ public class LabelDto {
 	) {
 	}
 
+	// DB 로부터 조회해오는 레이블
 	public record LabelRow(
 		int id,
 		String name,
@@ -83,5 +88,50 @@ public class LabelDto {
 		String color,
 		String textColor
 	) {
+	}
+
+	// 레이블 생성 요청 dto
+	public record LabelCreateRequest(
+		@NotBlank(message = "Label 이름은 필수입니다.")
+		@Size(max = 100, message = "Label 이름은 최대 100자 이내여야 합니다.")
+		String name,
+
+		String description,
+
+		@NotBlank(message = "배경색은 필수입니다.")
+		@Pattern(
+			regexp = "^#([0-9A-Fa-f]{6})$",
+			message = "색상은 #RRGGBB 형식이어야 합니다."
+		)
+		String color,
+
+		@NotBlank(message = "글자색은 필수입니다.")
+		@Pattern(
+			regexp = "^(WHITE|BLACK)$",
+			message = "글자 색은 WHITE 또는 BLACK 만 가능합니다."
+		)
+		String textColor
+	) {
+	}
+
+	// 넣을까 말까 고민... 윤이랑 상의해야 함
+	// 레이블 생성 후 응답하는 dto
+	@Builder
+	public record LabelCreateResponse(
+		int id,
+		String name,
+		String description,
+		String color,
+		String textColor
+	) {
+		public static LabelCreateResponse from(Label label) {
+			return new LabelCreateResponse(
+				label.getId(),
+				label.getName(),
+				label.getDescription(),
+				label.getColor(),
+				label.getTextColor()
+			);
+		}
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/dto/LabelDto.java
@@ -139,8 +139,6 @@ public class LabelDto {
 
 	// 레이블 수정 요청 dto
 	public record LabelUpdateRequest(
-		int id,
-
 		@NotBlank(message = "Label 이름은 필수입니다.")
 		@Size(max = 100, message = "Label 이름은 최대 100자 이내여야 합니다.")
 		String name,

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
@@ -24,6 +24,8 @@ public interface LabelRepository extends CrudRepository<Label, Integer>, LabelQu
 
 	boolean existsByName(String name);
 
+	boolean existsById(int id);
+
 	Optional<Label> findById(int id);
 
 	// name 같고 id 다른 레코드가 있으면 true 반환

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
@@ -20,4 +20,6 @@ public interface LabelRepository extends CrudRepository<Label, Integer>, LabelQu
 		WHERE deleted_at IS NULL
 		""")
 	List<LabelDto.LabelRow> findLabels();
+
+	boolean existsByName(String name);
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/repository/LabelRepository.java
@@ -1,6 +1,7 @@
 package codesquad.team01.issuetracker.label.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -22,4 +23,9 @@ public interface LabelRepository extends CrudRepository<Label, Integer>, LabelQu
 	List<LabelDto.LabelRow> findLabels();
 
 	boolean existsByName(String name);
+
+	Optional<Label> findById(int id);
+
+	// name 같고 id 다른 레코드가 있으면 true 반환
+	boolean existsByNameAndIdNot(String name, int id);
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import codesquad.team01.issuetracker.common.exception.DuplicateLabelName;
+import codesquad.team01.issuetracker.label.domain.Label;
 import codesquad.team01.issuetracker.label.dto.LabelDto;
 import codesquad.team01.issuetracker.label.repository.LabelRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,5 +32,23 @@ public class LabelService {
 			.totalCount(labels.size())
 			.labels(labels)
 			.build();
+	}
+
+	public LabelDto.LabelCreateResponse saveLabel(LabelDto.LabelCreateRequest request) {
+		String labelName = request.name();
+		if (labelRepository.existsByName(labelName)) {
+			throw new DuplicateLabelName("레이블 이름 중복");
+		}
+
+		Label entity = Label.builder()
+			.name(request.name())
+			.description(request.description())
+			.color(request.color())
+			.textColor(request.textColor())
+			.build();
+
+		Label savedLabel = labelRepository.save(entity);
+
+		return LabelDto.LabelCreateResponse.from(savedLabel);
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.team01.issuetracker.common.exception.DuplicateLabelName;
+import codesquad.team01.issuetracker.common.exception.LabelNotFoundException;
 import codesquad.team01.issuetracker.label.domain.Label;
 import codesquad.team01.issuetracker.label.dto.LabelDto;
 import codesquad.team01.issuetracker.label.repository.LabelRepository;
@@ -54,5 +55,23 @@ public class LabelService {
 		Label savedLabel = labelRepository.save(entity);
 
 		return LabelDto.LabelCreateResponse.from(savedLabel);
+	}
+
+	@Transactional
+	public LabelDto.LabelUpdateResponse updateLabel(int id, LabelDto.LabelUpdateRequest request) {
+		String newName = request.name();
+
+		Label updateTarget = labelRepository.findById(id)
+			.orElseThrow(() -> new LabelNotFoundException(newName));
+
+		// newName 과 동일한 이름을 가진 값 중에 id 가 다른 값이 있는지 확인 (중복확인)
+		if (labelRepository.existsByNameAndIdNot(newName, id)) {
+			throw new DuplicateLabelName(newName);
+		}
+
+		updateTarget.update(newName, request.description(), request.color(), request.textColor());
+		Label saved = labelRepository.save(updateTarget);
+
+		return LabelDto.LabelUpdateResponse.from(saved);
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -62,7 +62,7 @@ public class LabelService {
 		String newName = request.name();
 
 		Label updateTarget = labelRepository.findById(id)
-			.orElseThrow(() -> new LabelNotFoundException(newName));
+			.orElseThrow(() -> new LabelNotFoundException(id));
 
 		// newName 과 동일한 이름을 가진 값 중에 id 가 다른 값이 있는지 확인 (중복확인)
 		if (labelRepository.existsByNameAndIdNot(newName, id)) {
@@ -73,5 +73,14 @@ public class LabelService {
 		Label saved = labelRepository.save(updateTarget);
 
 		return LabelDto.LabelUpdateResponse.from(saved);
+	}
+
+	@Transactional
+	public void deleteLabel(int id) {
+		Label targetLabel = labelRepository.findById(id)
+			.orElseThrow(() -> new LabelNotFoundException(id));
+
+		targetLabel.delete();
+		labelRepository.save(targetLabel);
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -4,13 +4,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.team01.issuetracker.common.exception.DuplicateLabelName;
 import codesquad.team01.issuetracker.label.domain.Label;
 import codesquad.team01.issuetracker.label.dto.LabelDto;
 import codesquad.team01.issuetracker.label.repository.LabelRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class LabelService {
@@ -34,10 +37,11 @@ public class LabelService {
 			.build();
 	}
 
+	@Transactional
 	public LabelDto.LabelCreateResponse saveLabel(LabelDto.LabelCreateRequest request) {
-		String labelName = request.name();
+		String labelName = request.name().trim();
 		if (labelRepository.existsByName(labelName)) {
-			throw new DuplicateLabelName("레이블 이름 중복");
+			throw new DuplicateLabelName(labelName);
 		}
 
 		Label entity = Label.builder()

--- a/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/label/service/LabelService.java
@@ -39,7 +39,7 @@ public class LabelService {
 
 	@Transactional
 	public LabelDto.LabelCreateResponse saveLabel(LabelDto.LabelCreateRequest request) {
-		String labelName = request.name().trim();
+		String labelName = request.name();
 		if (labelRepository.existsByName(labelName)) {
 			throw new DuplicateLabelName(labelName);
 		}


### PR DESCRIPTION
## 작업 내용
- 레이블 CUD 기능 구현  
  - **생성**: `POST /api/v1/labels` → `LabelCreateRequest` DTO → `LabelService#createLabel()` → `LabelRepository.save()` → `201 Created` + `Location` 헤더  
  - **수정**: `PUT /api/v1/labels/{id}` → `LabelUpdateRequest` DTO + `@PathVariable id` → `LabelService#updateLabel(id, req)` → `LabelRepository.save()` → `200 OK`  
  - **삭제**: `DELETE /api/v1/labels/{id}` → `LabelService#deleteLabel(id)` (soft‐delete) → `204 No Content`  
- DTO/Entity/Repository/Service/Controller 각 레이어 구현  
- JSR-303 검증(`@NotBlank`, `@Size`, `@Pattern`, `@Pattern("^(WHITE|BLACK)$")`) 적용  
- `GlobalExceptionHandler`로 `DuplicateLabelName`, `LabelNotFoundException` 일원화 처리  
- API 명세서 및 Postman 컬렉션 업데이트

## 작업 진행 방식
- 브랜치 전략  
  1. `feature/27-label-update`에서 수정 기능을 구현했습니다.
  2. `git checkout -b feature/28-label-delete` → 삭제 기능을 구현했습니다.
- Task 분할: DTO → Repository → Service → Controller → 예외 처리 → 테스트 → 문서화 순으로 점진적으로 완료하였습니다.
  3. 다른 사람과 커밋이 조금 꼬여서 제 작업 부분만 feature/label-cud 브랜치에 cherry-pick 했습니다.

## 테스트 작업 방식
- Postman과 Mysql로 실제 API 호출 및 응답 , DB 저장 및 업데이트를 확인했습니다.

## 배포 방식
- GitHub Action을 사용한 백엔드 자동 배포를 시도했습니다.

## 지난 주에 비해 잘한 점
- 전역 예외 핸들러로 컨트롤러 코드를 간결화 하고, 일관된 에러 처리 로직을 구현했습니다.
- `@LastModifiedDate` 기반 소프트 삭제 로직(BaseEntity)을 적용했습니다.

## 부족한 점
- 테스트 코드를 구현하지 못했습니다.

## 앞으로 진행할 작업
- 마일스톤 CRUD 작업을 할 예정입니다.
- 백엔드, 프론트엔드 연동하여 ec2 환경에서 자동 배포를 시도할 예정입니다.

## 고민사항
- 아직 구현할 기능이 많은데 일주일밖에 남지 않았다는 게 믿기지 않습니다ㅠㅠ 남은 일주일 동안 어떤 기능을 더 구현하거나, 혹은 어떤 기능을 더 리팩토링하는게 더 좋은 방향일지 고민이 됩니다.
