### PR TITLE
[Team-01] 4주차 PR - 지토 (Login)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     // Spring Security 암호화 (PasswordEncoder 등)
     implementation 'org.springframework.security:spring-security-crypto'

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/api/AuthController.java
@@ -2,11 +2,13 @@ package codesquad.team01.issuetracker.auth.api;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,11 +18,13 @@ import codesquad.team01.issuetracker.auth.service.TokenService;
 import codesquad.team01.issuetracker.auth.util.AuthorizationUrlBuilder;
 import codesquad.team01.issuetracker.common.dto.ApiResponse;
 import codesquad.team01.issuetracker.user.domain.User;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@RequestMapping("/api")
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
@@ -76,4 +80,17 @@ public class AuthController {
 
 		return ApiResponse.success(tokens);
 	}
+
+	// 인증한 사용자 username, profileImageUrl
+	@GetMapping("/v1/auth/me")
+	public ApiResponse<?> getUsernameAndProfileImage(HttpServletRequest request) {
+		String username = (String)request.getAttribute("username");
+		String profileImage = (String)request.getAttribute("profileImageUrl");
+
+		return ApiResponse.success(Map.of(
+			"username", username,
+			"profileImage", profileImage
+		));
+	}
+
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtAuthenticationFilter.java
@@ -41,28 +41,23 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 		log.info("JWT 필터 동작: {}", path);
 
 		// OPTIONS 요청 시(CORS에 관련) 다음 필터로 넘김
-		if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
-			chain.doFilter(request, response);
-			return;
-		}
+		//if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+		//	chain.doFilter(request, response);
+		//	return;
+		//}
 
-		//토큰 추출 (없으면 TokenNotFoundException)
 		String token = JwtExtractor.extractJwt(request);
 		log.info("Access Token:{}", token);
 
-		//토큰 파싱·검증 (서명, 만료 체크)
 		Claims claims = jwtManager.parseClaims(token);
 
-		//subject(userId) 및 클레임 꺼내기
 		Integer userId = Integer.valueOf(claims.getSubject());
 		String username = claims.get("username", String.class);
 		String profileImageUrl = claims.get("profileImageUrl", String.class);
 
-		//DB 에서 실제 User 조회
 		User user = userRepository.findById(userId)
 			.orElseThrow(UserNotFoundException::new);
 
-		//인증 정보 request 에 세팅
 		request.setAttribute("authenticatedUser", user);
 		request.setAttribute("username", username);
 		request.setAttribute("profileImageUrl", profileImageUrl);

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package codesquad.team01.issuetracker.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.web.filter.GenericFilterBean;
+
+import codesquad.team01.issuetracker.auth.util.JwtExtractor;
+import codesquad.team01.issuetracker.auth.util.UserAuthorizationJwtManager;
+import codesquad.team01.issuetracker.common.exception.UserNotFoundException;
+import codesquad.team01.issuetracker.user.domain.User;
+import codesquad.team01.issuetracker.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+	private final UserAuthorizationJwtManager jwtManager;
+	private final UserRepository userRepository;
+
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
+		throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest)req;
+		HttpServletResponse response = (HttpServletResponse)res;
+
+		String path = request.getRequestURI();
+		//필터를 거치지 않을 경로
+		if (path.equals("/api/v1/auth/login") || path.startsWith("/api/v1/oauth")) {
+			chain.doFilter(request, response);
+			return;
+		}
+		log.info("JWT 필터 동작: {}", path);
+
+		// OPTIONS 요청 시(CORS에 관련) 다음 필터로 넘김
+		if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+			chain.doFilter(request, response);
+			return;
+		}
+
+		//토큰 추출 (없으면 TokenNotFoundException)
+		String token = JwtExtractor.extractJwt(request);
+		log.info("Access Token:{}", token);
+
+		//토큰 파싱·검증 (서명, 만료 체크)
+		Claims claims = jwtManager.parseClaims(token);
+
+		//subject(userId) 및 클레임 꺼내기
+		Integer userId = Integer.valueOf(claims.getSubject());
+		String username = claims.get("username", String.class);
+		String profileImageUrl = claims.get("profileImageUrl", String.class);
+
+		//DB 에서 실제 User 조회
+		User user = userRepository.findById(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		//인증 정보 request 에 세팅
+		request.setAttribute("authenticatedUser", user);
+		request.setAttribute("username", username);
+		request.setAttribute("profileImageUrl", profileImageUrl);
+
+		chain.doFilter(request, response);
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtExceptionFilter.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,57 @@
+package codesquad.team01.issuetracker.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquad.team01.issuetracker.common.dto.ApiResponse;
+import codesquad.team01.issuetracker.common.exception.TokenNotFoundException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain chain)
+		throws ServletException, IOException {
+
+		try {
+			chain.doFilter(request, response);
+		} catch (JwtException e) {
+			log.warn("JWT 검증 실패: {}", e.getMessage());
+			writeErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+		} catch (TokenNotFoundException e) {
+			log.debug("토큰 없음: {}", e.getMessage());
+			writeErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+		}
+	}
+
+	private void writeErrorResponse(HttpServletResponse res, int status, String message) throws IOException {
+		res.setStatus(status);
+		res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		res.setCharacterEncoding("UTF-8");
+		String body = objectMapper.writeValueAsString(ApiResponse.error(message));
+		res.getWriter().write(body);
+	}
+
+	//필터를 거치지 않을 경로
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		String path = request.getRequestURI();
+		return path.startsWith("/api/v1/auth/login") || path.startsWith("/api/v1/oauth/");
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtExceptionFilter.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/filter/JwtExceptionFilter.java
@@ -28,14 +28,16 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 		HttpServletResponse response,
 		FilterChain chain)
 		throws ServletException, IOException {
-
 		try {
+			//토큰 존재여부 판단과 같은 JwtException에 대한 필터링 기능 추가 필요
+
 			chain.doFilter(request, response);
+
 		} catch (JwtException e) {
-			log.warn("JWT 검증 실패: {}", e.getMessage());
+			log.warn("JWT 검증이 실패하였습니다: {}", e.getMessage());
 			writeErrorResponse(response, HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않은 토큰입니다.");
 		} catch (TokenNotFoundException e) {
-			log.debug("토큰 없음: {}", e.getMessage());
+			log.debug("토큰이 없습니다: {}", e.getMessage());
 			writeErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
 		}
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/util/JwtExtractor.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/util/JwtExtractor.java
@@ -1,0 +1,18 @@
+package codesquad.team01.issuetracker.auth.util;
+
+import codesquad.team01.issuetracker.common.exception.TokenNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class JwtExtractor {
+
+	public static final String JWT_HEADER = "Authorization";
+	public static final String BEARER = "Bearer ";
+
+	public static String extractJwt(HttpServletRequest request) {
+		String authHead = request.getHeader(JWT_HEADER);
+		if (authHead != null && authHead.startsWith(BEARER)) {
+			return authHead.replace(BEARER, "");
+		}
+		throw new TokenNotFoundException();
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/auth/util/UserAuthorizationJwtManager.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/auth/util/UserAuthorizationJwtManager.java
@@ -24,8 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class UserAuthorizationJwtManager {
 
-	@Value("${JWT_SECRET_KEY}")
-	private String SECRET_KEY;
 	private final SecretKey key;
 
 	@Value("${JWT_ACCESS_TOKEN_LIFETIME}")
@@ -34,11 +32,9 @@ public class UserAuthorizationJwtManager {
 	@Value("${JWT_REFRESH_TOKEN_LIFETIME}")
 	private final long refreshTokenLifetime;
 
-	public UserAuthorizationJwtManager(
-		@Value("${JWT_SECRET_KEY}") String secretKey,
+	public UserAuthorizationJwtManager(@Value("${JWT_SECRET_KEY}") String secretKey,
 		@Value("${JWT_ACCESS_TOKEN_LIFETIME}") long accessTokenLifetime,
-		@Value("${JWT_REFRESH_TOKEN_LIFETIME}") long refreshTokenLifetime
-	) {
+		@Value("${JWT_REFRESH_TOKEN_LIFETIME}") long refreshTokenLifetime) {
 		this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
 		this.accessTokenLifetime = accessTokenLifetime;
 		this.refreshTokenLifetime = refreshTokenLifetime;
@@ -69,10 +65,7 @@ public class UserAuthorizationJwtManager {
 
 	public Claims parseClaims(String token) {
 		try {
-			Jwt<?, Claims> jwt = Jwts.parser()
-				.verifyWith(key)
-				.build()
-				.parseSignedClaims(token);
+			Jwt<?, Claims> jwt = Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
 			return jwt.getPayload();
 		} catch (JwtException e) {
 			throw new IllegalArgumentException("허용되지 않거나 만료된 토큰입니다");
@@ -81,21 +74,18 @@ public class UserAuthorizationJwtManager {
 
 	public boolean validateRefreshToken(String token) {
 		try {
-			Jwt<?, Claims> jwt = Jwts.parser()
-				.verifyWith(key)
-				.build()
-				.parseSignedClaims(token);
+			Jwt<?, Claims> jwt = Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
 			return true;
 		} catch (ExpiredJwtException e) {
-			log.info("Refresh token이 만료되었습니다. " + e.getCause() + "에 의해 " + e.getMessage() + "가 발생하였습니다.");
+			log.info("Refresh token이 만료되었습니다. : {}", e.getMessage());
 		} catch (UnsupportedJwtException e) {
-			log.info("지원하지 않는 JWT 형식입니다. " + e.getCause() + "에 의해 " + e.getMessage() + "가 발생하였습니다.");
+			log.info("지원하지 않는 JWT 형식입니다. : {}", e.getMessage());
 		} catch (MalformedJwtException e) {
-			log.info("토큰이 올바르지 않거나 Base64 디코딩이 불가능합니다. " + e.getCause() + "에 의해 " + e.getMessage() + "가 발생하였습니다.");
+			log.info("토큰이 올바르지 않거나 Base64 디코딩이 불가능합니다. : {}", e.getMessage());
 		} catch (SignatureException e) {
-			log.info("서명 검증이 실패하였습니다. " + e.getCause() + "에 의해 " + e.getMessage() + "가 발생하였습니다.");
+			log.info("서명 검증이 실패하였습니다. : {}", e.getMessage());
 		} catch (IllegalArgumentException e) {
-			log.info("메서드에 잘못된 인자가 있습니다. " + e.getCause() + "에 의해 " + e.getMessage() + "가 발생하였습니다.");
+			log.info("메서드에 잘못된 인자가 있습니다. : {}", e.getMessage());
 		}
 		return false;
 	}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/FilterConfig.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/FilterConfig.java
@@ -1,0 +1,36 @@
+package codesquad.team01.issuetracker.common.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquad.team01.issuetracker.auth.filter.JwtAuthenticationFilter;
+import codesquad.team01.issuetracker.auth.filter.JwtExceptionFilter;
+import codesquad.team01.issuetracker.auth.util.UserAuthorizationJwtManager;
+import codesquad.team01.issuetracker.user.repository.UserRepository;
+
+@Configuration
+public class FilterConfig {
+
+	@Bean
+	public FilterRegistrationBean<JwtExceptionFilter> jwtExceptionFilter(ObjectMapper objectMapper) {
+		var bean = new FilterRegistrationBean<JwtExceptionFilter>();
+		bean.setFilter(new JwtExceptionFilter(objectMapper));
+		bean.addUrlPatterns("/api/*");   // 이 경로로 들어오는
+		bean.setOrder(1); //예외 필터 먼저 실행
+		return bean;
+	}
+
+	@Bean
+	public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilter(
+		UserAuthorizationJwtManager jwtManager,
+		UserRepository userRepository) {
+		var bean = new FilterRegistrationBean<JwtAuthenticationFilter>();
+		bean.setFilter(new JwtAuthenticationFilter(jwtManager, userRepository));
+		bean.addUrlPatterns("/api/*"); // -> /api/으로 시작하는 경로만 필터 적용
+		bean.setOrder(2);                   // 예외 필터 다음으로 실행
+		return bean;
+	}
+}

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/config/WebConfig.java
@@ -18,7 +18,7 @@ public class WebConfig implements WebMvcConfigurer {
 
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("api/**")
+		registry.addMapping("/api/**")
 			.allowedOrigins("http://localhost:3000")
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
 			.allowCredentials(true);

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/GlobalExceptionHandler.java
@@ -60,14 +60,14 @@ public class GlobalExceptionHandler {
 	//아이디가 존재하지 않는 경우
 	@ExceptionHandler(UserNotFoundException.class)
 	public ResponseEntity<ApiResponse<?>> handleUserNotFound(UserNotFoundException e) {
-		log.error("UserNotFoundException : {}", e.getMessage());
+		log.info("UserNotFoundException : {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error("존재하지 않는 ID 입니다"));
 	}
 
 	//패스워드가 틀린 경우
 	@ExceptionHandler(InvalidPasswordException.class)
 	public ResponseEntity<ApiResponse<?>> handleInvalidPassword(InvalidPasswordException e) {
-		log.error("InvalidPasswordException : {}", e.getMessage());
+		log.info("InvalidPasswordException : {}", e.getMessage());
 		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("비밀번호가 일치하지 않습니다"));
 	}
 }

--- a/backend/src/main/java/codesquad/team01/issuetracker/common/exception/TokenNotFoundException.java
+++ b/backend/src/main/java/codesquad/team01/issuetracker/common/exception/TokenNotFoundException.java
@@ -1,0 +1,7 @@
+package codesquad.team01.issuetracker.common.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+	public TokenNotFoundException() {
+		super("헤더에 토큰이 존재하지 않습니다");
+	}
+}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -129,6 +129,6 @@ ALTER TABLE `issue_label`
 
 CREATE TABLE IF NOT EXISTS `refresh_token` (
       `id` INTEGER AUTO_INCREMENT PRIMARY KEY,
-      `user_id` INT UNIQUE,
+      `user_id` INT UNIQUE NOT NULL,
       `token` VARCHAR(1024) NOT NULL
 );


### PR DESCRIPTION
## 작업 내용
이번 주는 피드백을 반영하고 로그인 필터 기능(필터 체이닝)을 구현하였습니다!
JWT 인증 필터(JwtAuthenticationFilter)와 예외 필터(JwtExceptionFilter)를 작성하여 인증과 기초적인 인가(로그인한 사용자만 API 호출 권한 부여)를 작업하였습니다. 그리고 사용자가 로그인 하였을 시 프로필이미지를 반환해주는 API를 개발하였습니다.

## 작업 진행 방식

1. `/api/*` 경로에 대해 JWT 인증 필터가 적용되도록 FilterConfig에서 설정

2. 필터 체이닝 구현
`JwtExceptionFilter` 필터에서 검증된 후 다음 필터인 `JwtAuthenticationFilter`로 넘어가도록 함

   - 토큰이 없는 경우, JwtException 같은 예외가 발생하는 경우를 처리하는 JwtExceptionFilter 구현

   - JWT 토큰을 추출하고, 유효성을 검증하는 JwtAuthenticationFilter 구현

3. /api/v1/auth/login, /api/v1/oauth/* 경로는 필터 제외 처리
4. FilterRegistrationBean을 통해 필터 순서 제어(JwtExceptionFilter 필터가 먼저 실행되도록 함)
5. 로그인 한 사용자에게 프로필 이미지를 보여주는 API 구현 (`api/v1/auth/me`)

## 테스트 작업 방식
- Postman을 활용하여 토큰이 없는 요청, 유효하지 않은 토큰 요청, 정상 토큰 요청에 대해 테스트를 진행하였습니다.
- 인증된 사용자의 정보가 컨트롤러에서 request.getAttribute로 잘 전달되는지 확인하였습니다.

## 배포 방식
현재 로컬 환경에서 테스트를 완료하였습니다! 추후 배포할 예정입니다

## 지난 주에 비해 잘한 점, 부족한 점
잘한점
- 피드백을 통해 제 코드와 의사소통(질문하는 법, Q&A) 방식의 부족한 점을 고치려고 노력하였습니다! 앞으로도 코드나 의사소통 방법에 있어 부족한 점을 보완하기 위해 꾸준히 노력하겠습니다!

부족한 점
1. 기능 구현에 있어 작업속도가 더딘 것 같습니다! 남은 기간 동안 최선을 다해서 빠르게 기능 구현을 완료하겠습니다!
2. 로그인 필터를 구현하며 JwtExceptionFilter, JwtAuthenticationFilter만 단순하게 구현을 해서 토큰이 있는지, 사용자 정보 인증을 간단하게 구현했는데 필터 체이닝의 개념이 모호한 상태에서 구현을 하다보니 부족한 점이 많이 있었던 것 같습니다! 필터 기능도 계속해서 보완해보려고 합니다!

## 앞으로 진행할 작업
1. 로그아웃, 회원가입 기능 개발
2. 필터 기능 보완
3. Refresh Token Rotation 구현

## 고민사항
필터 체이닝을 구현하는 과정에서 고민이 있습니다!
저는 필터 체이닝 방식을 구현하며 토큰이 없는 경우와 관련된 필터(JwtExceptionFilter)를 구현하였는데, try - catch문으로 구현하는 과정에서 catch문으로 TokenNotFoundException과 JwtException과 같은 토큰에 관련된 예외들을 처리해주는 방식으로 구현했는데, 이 방식이 필터 체이닝을 맞게 구현한 것인지..?에 대한 고민이 있습니다. 필터기능은 잘 동작하지만 제가 생각하기에 try문에서 다음 필터(JwtAuthenticationFilter)로 그냥 넘기는 것 같아서 try-catch로 구현한 JwtExceptionFilter가 필터 역할을 하지 않는 것 같은 문제점이 있는 것 같습니다.
만약 JwtExceptionFilter를 구현할 경우 혹은 로그인 필터를 구현할 때 어떠한 것들을 필터링 하는 것으로 구현하면 좋은지에 대해서 궁금합니다! ( 제가 구현한 필터 기능이 현업에서 인증/인가 필터를 구현한 것과 많은 차이가 있는지 궁금합니다!)