### PR TITLE
[Team-04, BE] 인가로직 및 필터링별 이슈 갯수 조회 기능 + 짜잘한 버그 수정 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+
     //bcrypt
     implementation 'org.mindrot:jbcrypt:0.4'
     //jwt

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
 
     //bcrypt
     implementation 'org.mindrot:jbcrypt:0.4'

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
     public ApiResponse<AuthResponseDto.LoginResponseDto> login(
         @RequestBody @Valid AuthRequestDto.LoginRequestDto requestDto,  HttpServletResponse response) {
 
-        User user = authService.checkEmailAndPassword(requestDto);
+        User user = authService.authenticateUser(requestDto);
 
         String token = jwtProvider.createToken(user.getId());
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
@@ -25,11 +25,24 @@ public class AuthInterceptor implements HandlerInterceptor {
     public static final String USER_ATTRIBUTE = "authenticatedUser";
     private static final String NEED_LOGIN = "로그인이 필요합니다.";
     private static final String NOT_FOUND_USER = "사용자를 찾을 수 없습니다.";
+    private static final String TOKEN_EXPIRED = "토큰이 만료되었습니다.";
+    private static final String TOKEN_INVALID = "토큰이 유효하지않습니다.";
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
         Optional<String> token = extractTokenFromCookies(request.getCookies());
-        if (token.isEmpty() || !jwtProvider.isValid(token.get())) {
+        if (token.isEmpty()) {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, NEED_LOGIN);
+            return false;
+        }
+
+        TokenValidationResult result = jwtProvider.isValid(token.get());
+        if (result == TokenValidationResult.EXPIRED) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, TOKEN_EXPIRED);
+            return false;
+        }
+
+        if (result == TokenValidationResult.INVALID) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, TOKEN_INVALID);
             return false;
         }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -8,13 +8,12 @@ import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
 import codesquad.team4.issuetracker.entity.User;
 import codesquad.team4.issuetracker.exception.ExceptionMessage;
 import codesquad.team4.issuetracker.exception.badrequest.InvalidLoginTypeException;
-import codesquad.team4.issuetracker.exception.unauthorized.PasswordNotEqualException;
 import codesquad.team4.issuetracker.exception.conflict.EmailAlreadyExistException;
 import codesquad.team4.issuetracker.exception.conflict.NicknameAlreadyExistException;
+import codesquad.team4.issuetracker.exception.unauthorized.PasswordNotEqualException;
 import codesquad.team4.issuetracker.exception.unauthorized.UserByEmailNotFoundException;
 import codesquad.team4.issuetracker.user.UserRepository;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.mindrot.jbcrypt.BCrypt;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,17 +48,15 @@ public class AuthService {
     }
 
     private void validateDuplicateEmailOrNickname(SignupRequestDto request) {
-        Optional<User> duplicate = userRepository.findByEmailOrNickname(request.getEmail(), request.getNickname());
-
-        if (duplicate.isPresent()) {
-            User user = duplicate.get();
-            if (user.getEmail().equals(request.getEmail())) {
-                throw new EmailAlreadyExistException(EMAIL_ALREADY_EXIST);
-            }
-            if (user.getNickname().equals(request.getNickname())) {
-                throw new NicknameAlreadyExistException(NICKNAME_ALREADY_EXIST);
-            }
-        }
+        userRepository.findByEmailOrNickname(request.getEmail(), request.getNickname())
+                .ifPresent(user -> {
+                    if (user.getEmail().equals(request.getEmail())) {
+                        throw new EmailAlreadyExistException(EMAIL_ALREADY_EXIST);
+                    }
+                    if (user.getNickname().equals(request.getNickname())) {
+                        throw new NicknameAlreadyExistException(NICKNAME_ALREADY_EXIST);
+                    }
+                });
     }
 
     public User checkEmailAndPassword(LoginRequestDto request) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -59,7 +59,7 @@ public class AuthService {
                 });
     }
 
-    public User checkEmailAndPassword(LoginRequestDto request) {
+    public User authenticateUser(LoginRequestDto request) {
         User user = userRepository.findByEmail(request.getEmail())
             .orElseThrow(UserByEmailNotFoundException::new);
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/JwtProvider.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/JwtProvider.java
@@ -4,6 +4,8 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
 import java.util.Date;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -13,7 +15,12 @@ public class JwtProvider {
 
     @Value("${jwt.secret}")
     private String secret;
+    private Key key;
     private final long expiration = 1000 * 60 * 30; //30분
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
 
     public String createToken(Long userId) {
         Date now = new Date();
@@ -21,7 +28,7 @@ public class JwtProvider {
             .setSubject(String.valueOf(userId))
             .setIssuedAt(now)
             .setExpiration(new Date(now.getTime() + expiration))
-            .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
+            .signWith(key, SignatureAlgorithm.HS256)
             .compact();
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/TokenValidationResult.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/TokenValidationResult.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.auth;
+
+public enum TokenValidationResult {
+    VALID,
+    EXPIRED,
+    INVALID
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -25,7 +25,11 @@ public class OAuthController {
 
     @GetMapping("/login")
     public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session) {
-        OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.createGithubAuthorizeUrl(session);
+        //session에 state 저장
+        String state = oAuthService.createGithubAuthorizeState();
+        session.setAttribute("oauth_state", state);
+        //Github 인증 URL 구성
+        OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.buildGithubAuthorizeUrl(state);
         return ResponseEntity.ok(githubUrl);
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -5,6 +5,7 @@ import codesquad.team4.issuetracker.auth.dto.AuthResponseDto;
 import codesquad.team4.issuetracker.auth.oauth.dto.OAuthRequestDto;
 import codesquad.team4.issuetracker.auth.oauth.dto.OAuthResponseDto;
 import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidOAuthStateException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,13 @@ public class OAuthController {
 
     //GitHub 인증 처리 + 로그인/회원가입
     private User processOAuthCallback(String code, String state, HttpSession session) {
-        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state), session);
+        //state 값 비교
+        String savedState = (String) session.getAttribute("oauth_state");
+        if (!state.equals(savedState)) {
+            throw new InvalidOAuthStateException();
+        }
+
+        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state));
     }
 
     //JWT 발급 및 쿠키 설정

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -25,10 +25,11 @@ public class OAuthController {
     private final JwtProvider jwtProvider;
 
     @GetMapping("/login")
-    public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session) {
+    public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session, HttpServletResponse response) {
         //session에 state 저장
         String state = oAuthService.createGithubAuthorizeState();
         session.setAttribute("oauth_state", state);
+
         //Github 인증 URL 구성
         OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.buildGithubAuthorizeUrl(state);
         return ResponseEntity.ok(githubUrl);
@@ -52,7 +53,7 @@ public class OAuthController {
 
     //state 인증 + session 만료
     private void validateState(String state, HttpSession session) {
-        String savedState = (String) session.getAttribute("oauth_sate");
+        String savedState = (String) session.getAttribute("oauth_state");
         if (!state.equals(savedState)) {
             throw new InvalidOAuthStateException();
         }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -46,13 +46,17 @@ public class OAuthController {
 
     //GitHub 인증 처리 + 로그인/회원가입
     private User processOAuthCallback(String code, String state, HttpSession session) {
-        //state 값 비교
-        String savedState = (String) session.getAttribute("oauth_state");
+        validateState(state, session);
+        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code));
+    }
+
+    //state 인증 + session 만료
+    private void validateState(String state, HttpSession session) {
+        String savedState = (String) session.getAttribute("oauth_sate");
         if (!state.equals(savedState)) {
             throw new InvalidOAuthStateException();
         }
-
-        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state));
+        session.invalidate();
     }
 
     //JWT 발급 및 쿠키 설정

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -42,11 +42,7 @@ public class OAuthService {
     private static final String GITHUB_USER_EMAIL_API_URL = "https://api.github.com/user/emails";
 
 
-    public OAuthResponseDto.OAuthLoginUrl createGithubAuthorizeUrl(HttpSession session) {
-        //state 생성 및 세션에 저장
-        String state = UUID.randomUUID().toString();
-        session.setAttribute("oauth_state", state);
-
+    public OAuthResponseDto.OAuthLoginUrl buildGithubAuthorizeUrl(String state) {
         //Github 인증 URL 구성
         String githubUrl = UriComponentsBuilder.fromHttpUrl(GITHUB_AUTHORIZE_URL)
             .queryParam("client_id", clientId)
@@ -59,6 +55,11 @@ public class OAuthService {
         return OAuthResponseDto.OAuthLoginUrl.builder()
             .url(githubUrl)
             .build();
+    }
+
+    public String createGithubAuthorizeState() {
+        //state 생성
+        return UUID.randomUUID().toString();
     }
 
     public User handleCallback(OAuthRequestDto.GitHubCallback callback, HttpSession session) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -69,7 +69,6 @@ public class OAuthService {
         OAuthResponseDto.GitHubUserResponse userInfo = fetchGitHubUser(accessToken);
         //회원가입/로그인 처리
         Optional<User> optionalUser = userRepository.findByEmail(userInfo.getEmail());
-
         if (optionalUser.isPresent()) {
             User user = optionalUser.get();
             validateLoginType(user);

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -62,13 +62,7 @@ public class OAuthService {
         return UUID.randomUUID().toString();
     }
 
-    public User handleCallback(OAuthRequestDto.GitHubCallback callback, HttpSession session) {
-        //state 값 비교
-        String savedState = (String) session.getAttribute("oauth_state");
-        if (!callback.getState().equals(savedState)) {
-            throw new InvalidOAuthStateException();
-        }
-
+    public User handleCallback(OAuthRequestDto.GitHubCallback callback) {
         //access tocken 요청
         String accessToken = requestAccessToken(callback.getCode());
         //Github 사용자 정보 요청

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/dto/OAuthRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/dto/OAuthRequestDto.java
@@ -11,6 +11,5 @@ public class OAuthRequestDto {
     @Builder
     public static class GitHubCallback {
         private String code;
-        private String state;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -4,10 +4,21 @@ import codesquad.team4.issuetracker.auth.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -35,6 +46,21 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        //커넥션 풀 설정
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(50);
+        connectionManager.setDefaultMaxPerRoute(20);
+
+        //HttpClient 생성
+        HttpClient httpClent = HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .build();
+
+        //RestTemplate에 사용할 팩토리 성정
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClent);
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+
+        return new RestTemplate(factory);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -4,21 +4,14 @@ import codesquad.team4.issuetracker.auth.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.core5.util.Timeout;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
+
+
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -46,21 +39,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestTemplate restTemplate() {
-        //커넥션 풀 설정
-        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setMaxTotal(50);
-        connectionManager.setDefaultMaxPerRoute(20);
-
-        //HttpClient 생성
-        HttpClient httpClent = HttpClients.custom()
-            .setConnectionManager(connectionManager)
-            .build();
-
-        //RestTemplate에 사용할 팩토리 성정
-        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClent);
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(3000);
         factory.setReadTimeout(5000);
-
         return new RestTemplate(factory);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
@@ -4,20 +4,19 @@ import codesquad.team4.issuetracker.count.CountDao;
 import codesquad.team4.issuetracker.issue.IssueEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.context.event.EventListener;
 
 @Component
 @RequiredArgsConstructor
 public class IssueCountListener {
     private final CountDao countDao;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onCreated(IssueEvent.Created e) {
         countDao.increment(CountDao.ISSUE_OPEN);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onStatusChanged(IssueEvent.StatusChanged e) {
         if (e.isClosing()) {
             countDao.decrement(CountDao.ISSUE_OPEN);
@@ -28,7 +27,7 @@ public class IssueCountListener {
         }
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onDeleted(IssueEvent.Deleted e) {
         if (e.isWasOpen()) {
             countDao.decrement(CountDao.ISSUE_OPEN);

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
@@ -5,8 +5,7 @@ import codesquad.team4.issuetracker.milestone.MilestoneEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.context.event.EventListener;
 
 @Slf4j
 @Component
@@ -14,12 +13,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class MilestoneCountListener {
     private final CountDao countDao;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onCreated(MilestoneEvent.Created e) {
         countDao.increment(CountDao.MILESTONE_OPEN);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onStatusChanged(MilestoneEvent.StatusChanged e) {
         if (e.isClosing()) {
             countDao.decrement(CountDao.MILESTONE_OPEN);
@@ -30,7 +29,7 @@ public class MilestoneCountListener {
         }
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onDeleted(MilestoneEvent.Deleted e) {
         if (e.isWasOpen()) {
             countDao.decrement(CountDao.MILESTONE_OPEN);

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -20,4 +20,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_EMAIL = "이메일을 공개로 전환해주세요.";
     public static final String INVALID_LOGINTYPE_GITHUB = "이메일로 로그인해 주세요.";
     public static final String INVALID_LOGINTYPE_LOCAL = "깃허브로 로그인해 주세요.";
+    public static final String NOT_AUTHOR = "작성자만 접근할 수 있습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/NotAuthorException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/NotAuthorException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.unauthorized;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_AUTHOR;
+
+public class NotAuthorException extends UnauthorizedException{
+    public NotAuthorException() {super(NOT_AUTHOR);}
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -9,7 +9,6 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import codesquad.team4.issuetracker.util.IssueFilteringParser;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -46,6 +46,7 @@
                 SELECT
                     i.issue_id AS issue_id,
                     i.title,
+                    i.created_at,
                     u.user_id AS author_id,
                     u.nickname AS author_nickname,
                     u.profile_image AS author_profile,
@@ -211,6 +212,7 @@
                 SELECT
                     i.content AS issue_content,
                     i.file_url AS issue_file_url,
+                    i.created_at AS created_at,
                     c.comment_id AS comment_id,
                     c.content AS comment_content,
                     c.file_url AS comment_file_url,

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -8,6 +8,7 @@
     import java.util.HashMap;
     import java.util.List;
     import java.util.Map;
+    import java.util.Set;
     import java.util.stream.Collectors;
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;
@@ -78,6 +79,34 @@
             params.put("isOpen", dto.getStatus().getState());
 
             // 작성자 필터
+            addfilteringConditionDynamic(dto, params, sql);
+
+            return sql.toString();
+        }
+
+        public Integer countIssuesByOpenStatus(boolean isOpen) {
+            String sql = "SELECT COUNT(*) FROM issue WHERE is_open = ?";
+            return jdbcTemplate.queryForObject(sql, Integer.class, isOpen);
+        }
+        public Map<String, Integer> countFilteredIssues(IssueFilterParamDto dto) {
+            StringBuilder sql = new StringBuilder("WITH filtered_issues AS (\n");
+            Map<String, Object> params = new HashMap<>();
+
+            sql.append("SELECT is_open FROM issue WHERE 1=1\n");
+
+            // 동적 필터링
+            addfilteringConditionDynamic(dto, params, sql);
+
+            sql.append(")\n");
+            sql.append("SELECT is_open, COUNT(*) as count FROM filtered_issues GROUP BY is_open");
+
+            List<Map<String, Object>> result = namedParameterJdbcTemplate.queryForList(sql.toString(), params);
+
+            return getCountMap(result);
+        }
+
+        private void addfilteringConditionDynamic(IssueFilterParamDto dto, Map<String, Object> params, StringBuilder sql) {
+            // 작성자 필터
             addAuthorCondition(dto.getAuthorId(), params, sql);
             // 담당자 필터
             addAssigneeCondition(dto.getAssigneeId(), params, sql);
@@ -87,21 +116,20 @@
             addMilestoneCondition(dto.getMilestoneId(), params, sql);
             // 라벨 필터
             addLabelConditions(dto.getLabelIds(), params, sql);
-
-            return sql.toString();
         }
 
-        private void addLabelConditions(List<Long> labelIds, Map<String, Object> params, StringBuilder sql) {
+        private void addLabelConditions(Set<Long> labelIds, Map<String, Object> params, StringBuilder sql) {
             // 라벨 필터링 - IN + GROUP BY + HAVING
             if (labelIds != null && !labelIds.isEmpty()) {
                 sql.append(" AND issue_id IN (\n");
                 sql.append("SELECT il.issue_id \nFROM issue_label il \nWHERE il.label_id IN (");
 
+                List<Long> labelList = new ArrayList<>(labelIds);
                 List<String> labelParamNames = new ArrayList<>();
                 for (int i = 0; i < labelIds.size(); i++) {
                     String paramName = "label" + i;
                     labelParamNames.add(":" + paramName);
-                    params.put(paramName, labelIds.get(i));
+                    params.put(paramName, labelList.get(i));
                 }
 
                 sql.append(String.join(", ", labelParamNames));
@@ -149,9 +177,22 @@
             }
         }
 
-        public Integer countIssuesByOpenStatus(boolean isOpen) {
-            String sql = "SELECT COUNT(*) FROM issue WHERE is_open = ?";
-            return jdbcTemplate.queryForObject(sql, Integer.class, isOpen);
+        private Map<String, Integer> getCountMap(List<Map<String, Object>> result) {
+            int open = 0, close = 0;
+            for (Map<String, Object> row : result) {
+                Boolean isOpen = (Boolean) row.get("is_open");
+                int count = ((Number) row.get("count")).intValue();
+                if (Boolean.TRUE.equals(isOpen)) {
+                    open = count;
+                } else {
+                    close = count;
+                }
+            }
+
+            Map<String, Integer> counts = new HashMap<>();
+            counts.put("open", open);
+            counts.put("close", close);
+            return counts;
         }
 
         public int updateIssueStatusByIds(boolean isOpen, List<Long> issueIds) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -30,6 +30,7 @@ import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import codesquad.team4.issuetracker.user.UserDao;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import codesquad.team4.issuetracker.user.dto.UserDto.UserInfo;
+import codesquad.team4.issuetracker.util.OpenStatus;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -88,7 +89,9 @@ public class IssueService {
         int closeCount = countMap.get("close");
 
         int totalElements = openCount + closeCount;
-        int totalPages = (int) Math.ceil((double) totalElements / size);
+        int totalPages = (int) Math.ceil((double) closeCount / size);;
+        if (params.getStatus() == OpenStatus.OPEN)
+            totalPages = (int) Math.ceil((double) openCount / size);
 
         return IssueResponseDto.IssueListDto.builder()
             .issues(new ArrayList<>(issueMap.values()))

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -7,10 +7,13 @@ import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.entity.User;
 import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
+import codesquad.team4.issuetracker.count.dto.IssueCountDto;
+import codesquad.team4.issuetracker.exception.unauthorized.NotAuthorException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -263,9 +266,12 @@ public class IssueService {
     }
 
     @Transactional
-    public ApiMessageDto updateIssue(Long id, IssueRequestDto.IssueUpdateDto request, String uploadUrl) {
+    public ApiMessageDto updateIssue(Long id, IssueRequestDto.IssueUpdateDto request, String uploadUrl, User user) {
         Issue oldIssue = issueRepository.findById(id)
                 .orElseThrow(() -> new IssueNotFoundException(id));
+
+        //작성자 검증
+        validateAuthor(oldIssue.getAuthorId(), user);
 
         if (request.getMilestoneId() != null) {
             milestoneRepository.findById(request.getMilestoneId())
@@ -400,12 +406,20 @@ public class IssueService {
     }
 
     @Transactional
-    public void deleteIssue(Long issueId) {
+    public void deleteIssue(Long issueId, User user) {
         Issue issue = issueRepository.findById(issueId)
                 .orElseThrow(() -> new IssueNotFoundException(issueId));
+
+        validateAuthor(issue.getAuthorId(), user);
 
         boolean wasOpen = issue.isOpen();
         issueRepository.deleteById(issueId);
         eventPublisher.publishEvent(new IssueEvent.Deleted(wasOpen));
+    }
+
+    private void validateAuthor (Long authorId, User user) {
+        if (!authorId.equals(user.getId())) {
+            throw new NotAuthorException();
+        }
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -12,7 +12,6 @@ import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
-import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.exception.unauthorized.NotAuthorException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -111,6 +111,7 @@ public class IssueService {
 
     private void addIssueToMap(Map<String, Object> row, Map<Long, IssueInfo> issueMap, Long issueId,
                                   Map<Long, Set<UserInfo>> assigneeMap, Map<Long, Set<LabelInfo>> labelMap) {
+        Timestamp createdAt = (Timestamp) row.get("created_at");
         issueMap.computeIfAbsent(issueId, id ->
                 IssueInfo.builder()
                         .id(issueId)
@@ -126,7 +127,8 @@ public class IssueService {
                                 .id((Long) row.get("milestone_id"))
                                 .title((String) row.get("milestone_title"))
                                 .build())
-                        .build()
+                    .createdAt(createdAt.toLocalDateTime())
+                .build()
         );
     }
 
@@ -240,7 +242,7 @@ public class IssueService {
 
         String issueContent = (String) issueById.get(0).get("issue_content");
         String issueImage = (String) issueById.get(0).get("issue_file_url");
-
+        Timestamp createdAt = (Timestamp) issueById.get(0).get("created_at");
         List<CommentResponseDto.CommentInfo> comments = issueById.stream()
                 .filter(row -> row.get("comment_id") != null) // 댓글이 없는 경우 필터링
                 .map(row -> CommentResponseDto.CommentInfo.builder()
@@ -259,6 +261,7 @@ public class IssueService {
         return IssueResponseDto.searchIssueDetailDto.builder()
                 .content(issueContent)
                 .contentFileUrl(issueImage)
+                .createdAt(createdAt.toLocalDateTime())
                 .comments(comments)
                 .commentSize(comments.size())
                 .build();

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -71,6 +71,6 @@ public class IssueRequestDto {
         private Long commentAuthorId;
         private Long milestoneId;
         private OpenStatus status;
-        private List<Long> labelIds;
+        private Set<Long> labelIds;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -46,6 +46,7 @@ public class IssueRequestDto {
         private Long milestoneId;
         private Boolean isOpen;
         private Boolean removeImage;
+        private Boolean removeMilestone;
     }
 
     @AllArgsConstructor

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -18,6 +18,8 @@ public class IssueResponseDto {
     @Builder
     public static class IssueListDto {
         private List<IssueInfo> issues;
+        private Integer openCount;
+        private Integer closeCount;
         private Integer page;
         private Integer size;
         private Integer totalPages;

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -4,6 +4,7 @@ import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +37,7 @@ public class IssueResponseDto {
         private Set<LabelInfo> labels;
         private Set<UserDto.UserInfo> assignees;
         private MilestoneResponseDto.MilestoneInfo milestone;
-        private String createdAt;
+        private LocalDateTime createdAt;
     }
 
     @AllArgsConstructor
@@ -61,6 +62,7 @@ public class IssueResponseDto {
     public static class searchIssueDetailDto {
         private String content;
         private String contentFileUrl;
+        private LocalDateTime createdAt;
         private List<CommentResponseDto.CommentInfo> comments;
         private Integer commentSize;
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
@@ -2,8 +2,8 @@ package codesquad.team4.issuetracker.util;
 
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class IssueFilteringParser {
     public static IssueRequestDto.IssueFilterParamDto parseFilterCondition(String query) {
@@ -14,7 +14,7 @@ public class IssueFilteringParser {
         Long assigneeId = null;
         Long milestoneId = null;
         Long commentAuthorId = null;
-        List<Long> labelIds = new ArrayList<>();
+        Set<Long> labelIds = new HashSet<>();
 
         for (String condition : conditions) {
             if (!condition.contains(":")) continue;

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -46,7 +46,7 @@ CREATE TABLE issue (
                        FOREIGN KEY (author_id) REFERENCES user(user_id),
                        FOREIGN KEY (milestone_id) REFERENCES milestone(milestone_id) ON DELETE SET NULL
 );
-
+CREATE INDEX idx_issue_created_open ON issue (created_at DESC, is_open);
 -- COMMENT
 CREATE TABLE comment (
                          comment_id BIGINT PRIMARY KEY AUTO_INCREMENT,

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthControllerTest.java
@@ -66,7 +66,7 @@ public class AuthControllerTest {
         AuthRequestDto.LoginRequestDto loginRequest = new AuthRequestDto.LoginRequestDto("test@example.com", "1234");
         String jwtToken = "mocked-jwt-token";
 
-        given(authService.checkEmailAndPassword(any())).willReturn(dummyUser);
+        given(authService.authenticateUser(any())).willReturn(dummyUser);
         given(jwtProvider.createToken(dummyUser.getId())).willReturn(jwtToken);
 
         // when & then
@@ -89,7 +89,7 @@ public class AuthControllerTest {
         // given
         AuthRequestDto.LoginRequestDto loginRequest = new AuthRequestDto.LoginRequestDto("wrong@example.com", "wrongpw");
 
-        given(authService.checkEmailAndPassword(any()))
+        given(authService.authenticateUser(any()))
             .willThrow(new UserByEmailNotFoundException());
 
         // when & then

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceTest.java
@@ -74,7 +74,7 @@ public class AuthServiceTest {
         given(userRepository.findByEmail("test@example.com"))
             .willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> authService.checkEmailAndPassword(request))
+        assertThatThrownBy(() -> authService.authenticateUser(request))
             .isInstanceOf(UserByEmailNotFoundException.class);
     }
 
@@ -93,7 +93,7 @@ public class AuthServiceTest {
         given(userRepository.findByEmail("test@example.com"))
             .willReturn(Optional.of(existingUser));
 
-        assertThatThrownBy(() -> authService.checkEmailAndPassword(request))
+        assertThatThrownBy(() -> authService.authenticateUser(request))
             .isInstanceOf(PasswordNotEqualException.class);
     }
 
@@ -112,7 +112,7 @@ public class AuthServiceTest {
         given(userRepository.findByEmail("test@example.com"))
             .willReturn(Optional.of(existingUser));
 
-        assertThatThrownBy(() -> authService.checkEmailAndPassword(request))
+        assertThatThrownBy(() -> authService.authenticateUser(request))
             .isInstanceOf(InvalidLoginTypeException.class)
             .hasMessageContaining("깃허브로 로그인해 주세요.");
     }

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/JwtProviderTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/JwtProviderTest.java
@@ -2,24 +2,23 @@ package codesquad.team4.issuetracker.auth;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+@SpringBootTest
 public class JwtProviderTest {
 
-    private JwtProvider jwtProvider;
+    @Autowired
+    private JwtProvider  jwtProvider;
 
     private final String secret = "testsecrettestsecrettestsecrettestsecret"; // 32 bytes 이상
 
     @BeforeEach
     void setUp() {
-        jwtProvider = new JwtProvider();
         ReflectionTestUtils.setField(jwtProvider, "secret", secret);
     }
 
@@ -39,42 +38,37 @@ public class JwtProviderTest {
     }
 
     @Test
-    @DisplayName("유효한 토큰이면 isValid가 true를 반환한다")
+    @DisplayName("유효한 토큰이면 result가 VALID를 반환한다")
     void isValid_validToken() {
         //when
         String token = jwtProvider.createToken(1L);
-        boolean isValid = jwtProvider.isValid(token);
+        TokenValidationResult result = jwtProvider.isValid(token);
 
         //then
-        assertThat(isValid).isTrue();
+        assertThat(result).isEqualTo(TokenValidationResult.VALID);
     }
 
     @Test
-    @DisplayName("잘못된 토큰이면 isValid가 false를 반환한다")
+    @DisplayName("잘못된 토큰이면 result가 INVALID를 반환한다")
     void isValid_invalidToken() {
         //when
         String invalidToken = "InvalidToken";
-        boolean isValid = jwtProvider.isValid(invalidToken);
+        TokenValidationResult result = jwtProvider.isValid(invalidToken);
 
         //then
-        assertThat(isValid).isFalse();
+        assertThat(result).isEqualTo(TokenValidationResult.INVALID);
     }
 
     @Test
-    @DisplayName("만료된 토큰이면 isValid가 false를 반환한다")
-    void isValid_expiredToken(){
+    @DisplayName("만료된 토큰이면 result가 EXPIRED를 반환한다")
+    void isValid_expiredToken() {
+        //give
+        String expiredToken = jwtProvider.createToken(1L, -1000L);
 
-        Date now = new Date();
-        Date expiredAt = new Date(now.getTime() - 1000); // 이미 만료된 시점
+        //when
+        TokenValidationResult result = jwtProvider.isValid(expiredToken);
 
-        String expiredToken = Jwts.builder()
-            .setSubject("1")
-            .setIssuedAt(now)
-            .setExpiration(expiredAt) // 만료된 시간
-            .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
-            .compact();
-
-        boolean isValid = jwtProvider.isValid(expiredToken);
-        assertThat(isValid).isFalse();
+        //then
+        assertThat(result).isEqualTo(TokenValidationResult.EXPIRED);
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -1,10 +1,11 @@
 package codesquad.team4.issuetracker.issue;
 
+import static codesquad.team4.issuetracker.util.IssueFilteringParser.parseFilterCondition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.count.dto.IssueCountDto;
+import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -12,13 +13,15 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueListDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.util.OpenStatus;
-import codesquad.team4.issuetracker.util.IssueFilteringParser;
 import codesquad.team4.issuetracker.util.TestDataHelper;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -281,7 +284,7 @@ class IssueServiceH2Test {
         Long milestoneId, Long commentAuthorId, List<Long> labelIds) {
 
         // given
-        IssueRequestDto.IssueFilterParamDto filterDto = IssueFilteringParser.parseFilterCondition(q);
+        IssueRequestDto.IssueFilterParamDto filterDto = parseFilterCondition(q);
 
         // when
         IssueResponseDto.IssueListDto result = issueService.getIssues(filterDto, 0, 10);
@@ -311,5 +314,39 @@ class IssueServiceH2Test {
                 assertThat(issueLabelIds).containsAll(labelIds);
             }
         });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIssueFilterDtosWithCounts")
+    @DisplayName("이슈를 필터링하는경우 필터링된 열린 이슈 갯수와 닫힌 이슈 갯수를 함께 응답한다")
+    void testFilteredIssueCounts(IssueFilterParamDto filterDto, int expectedOpen, int expectedClose) {
+        IssueResponseDto.IssueListDto result = issueService.getIssues(filterDto, 0, 10);
+
+        assertThat(result.getOpenCount()).isEqualTo(expectedOpen);
+        assertThat(result.getCloseCount()).isEqualTo(expectedClose);
+    }
+
+    private static Stream<Arguments> provideIssueFilterDtosWithCounts() {
+        return Stream.of(
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).assigneeId(2L).build(), 1, 1),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).commentAuthorId(3L).build(), 0, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).commentAuthorId(3L).build(), 0, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).commentAuthorId(2L).build(), 1, 1),
+            Arguments.of(
+                IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).labelIds(Set.of(1L)).build(), 0, 0),
+            Arguments.of(
+                IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).labelIds(Set.of(1L, 2L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).milestoneId(1L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).labelIds(Set.of(1L, 2L, 3L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).authorId(3L).assigneeId(4L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).milestoneId(2L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).labelIds(Set.of(5L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).commentAuthorId(2L).build(), 1, 1),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).labelIds(Set.of(1L)).build(), 2, 0)
+        );
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -4,6 +4,8 @@ import static codesquad.team4.issuetracker.util.IssueFilteringParser.parseFilter
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
@@ -44,6 +46,8 @@ class IssueServiceH2Test {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    private User author;
+
     @BeforeEach
     void setUp() {
         //유저 생성
@@ -81,6 +85,12 @@ class IssueServiceH2Test {
         TestDataHelper.insertComment(jdbcTemplate, 3L, "댓글3", 2L, 3L, null);
         TestDataHelper.insertComment(jdbcTemplate, 4L, "댓글4", 3L, 3L, null);
         TestDataHelper.insertComment(jdbcTemplate, 5L, "댓글5", 3L, 6L, null);
+
+        author = User.builder()
+            .id(1L)
+            .email("user1@test.com")
+            .nickname("사용자1")
+            .build();
     }
 
 
@@ -172,7 +182,7 @@ class IssueServiceH2Test {
         Long issueId = 999L;
 
         //when & then
-        assertThatThrownBy(() -> issueService.deleteIssue(issueId))
+        assertThatThrownBy(() -> issueService.deleteIssue(issueId, author))
             .isInstanceOf(IssueNotFoundException.class);
     }
 

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
@@ -24,7 +24,7 @@ public class IssueFilteringParserTest {
         assertThat(filterDto.getAssigneeId()).isEqualTo(assigneeId);
         assertThat(filterDto.getMilestoneId()).isEqualTo(milestoneId);
         assertThat(filterDto.getCommentAuthorId()).isEqualTo(commentAuthorId);
-        assertThat(filterDto.getLabelIds()).containsExactlyElementsOf(labelIds);
+        assertThat(filterDto.getLabelIds()).containsAnyElementsOf(labelIds);
     }
 
     private static Stream<Arguments> provideFilterConditions() {


### PR DESCRIPTION
배포 주소
https://issue-tracker.duckdns.org/issues

1. 작업내용
    * 인가 로직 처리
    * 필터링된 이슈 갯수 조회 API 작성
    * 연동을 위한 짜잘한 버그 수정
    * HTTPS 설정

2. 이번 주 달라진 점! 자랑할 점! 
    빙빙 : 카운트 쿼리를 처음 생각으로는 임시 테이블로 필터링된 이슈들을 가져오고 이를 재사용해서 갯수를 세려 했지만 row가 없는 경우 count를 가져오지 못하는 문제가 생겼습니다. 
    하나의 쿼리에서 필터링 조건을 재사용하는 대신 카운트 쿼리를 분리시키고 동적 쿼리를 만드는 메소드를 재사용하여 각 필터링 조건에 맞는 이슈 갯수를 가져 올 수 있도록 했습니다.
    
    브리 : 마지막으로 리팩토링을 하면서 생각보다 놓치고 있던 디테일한 부분이 많다는 것을 느겼습니다. 동시에 "이 부분은 다음에 이렇게 구현해야 겠다."는 기준도 조금 생긴 것 같습니다.
    
3. 리뷰 소감
    빙빙 : 리뷰를 받는 것을 전제로 코드를 짜면서 코드 하나하나에 더 고민을 하게 되고 의도를 담게 되었던 것 같습니다. 그냥 ai가 만들어준 코드가 아니라 어떤 로직, 어떤 자료구조 등 내 생각이 드러날 수 있는 코드를 짜는 것이 중요하다는 걸 알게 되었습니다.
    코드를 짜면서 놓쳤던 것들, 한 걸음  더 깊게 들어갈 수 있는 부분들을 리뷰 받으면서 생각 할 수 있게되어서 나그한테도 감사하고 덕분에 많이 배울 수 있었습니다. 
    프로젝트 진행하면서 코드 스타일이나 로직을 제가 원하는 쪽으로 많이 주장을 했는데 잘 따라와주고 질문 많이 해준 브리에게도 고맙습니다.
    
    브리 : 프로젝트를 진행하면서 리뷰어님의 꼼꼼한 피드백 덕분에 많이 배울 수 있었습니다. 기능 구현에만 집중하느라 놓쳤던 부분들을 리뷰를 통해 짚어주셔서, 코드의 방향성과 구조에 대해 더 깊이 고민할 수 있었던 것 같습니다. 단순한 "작동하는 코드"가 아니라 "왜 이렇게 구현했는가"를 설명할 수 있는 코드가 중요하다는 것을 느낄 수 있었던 시간이였습니다. 
    처음 해보는 프로젝트라고 할 수 있는데, 빙빙 덕분에 많이 배우고 끝까지 완주 할 수 있었던 것 같아 감사합니다!

    
5. 기타
    이번주는 기능 구현 자체는 많이 없고 연동시에 찾은 버그를 수정하는데에 시간을 사용했습니다.